### PR TITLE
There is no file called 'server.js' in ./server

### DIFF
--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -32,7 +32,7 @@ Now let's setup the required dependencies. Create a file called `package.json` a
   "version": "1.0.0",
   "description": "My first multi-user virtual reality",
   "scripts": {
-    "start": "node ./server/server.js"
+    "start": "node ./server/easyrtc-server.js"
   },
   "author": "YOUR_NAME",
   "dependencies": {


### PR DESCRIPTION
Following along with the getting started tutorial npm threw: `Error: Cannot find module '/home/miles/repos/naf-tutorial/server/server.js` when I tried to `npm start`. I think you meant to use the `easyrtc-server.js`?