### PR TITLE
Use setAttribute to change component data

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -131,8 +131,7 @@ AFRAME.registerComponent('networked', {
   },
 
   onConnected: function() {
-    this.data.owner = NAF.clientId;
-    this.el.setAttribute('networked', {networkId: NAF.utils.createNetworkId()});
+    this.el.setAttribute(this.name, {owner: NAF.clientId});
   },
 
   isMine: function() {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -25,7 +25,7 @@ AFRAME.registerComponent('networked', {
     this.initNetworkParent();
 
     if (data.networkId === '') {
-      data.networkId = NAF.utils.createNetworkId();
+      this.el.setAttribute(this.name, {networkId: NAF.utils.createNetworkId()});
     }
 
     if (data.template != '') {
@@ -132,6 +132,7 @@ AFRAME.registerComponent('networked', {
 
   onConnected: function() {
     this.data.owner = NAF.clientId;
+    this.el.setAttribute('networked', {networkId: NAF.utils.createNetworkId()});
   },
 
   isMine: function() {

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -77,6 +77,16 @@ suite('networked', function() {
       assert.equal(result, 'nid1');
     }));
 
+    test.only('retains networkId after component update', sinon.test(function() {
+      this.stub(naf.utils, 'createNetworkId').returns('nid-after-load');
+
+      networked.init();
+
+      // A-Frame can call updateComponents for mulitple reasons. This can result in component data being rebuilt.
+      entity.updateComponents();
+      assert.equal(networked.data.networkId, 'nid-after-load');
+    }));
+
     test('sets owner', sinon.test(function() {
       naf.clientId = 'owner1';
 
@@ -159,7 +169,7 @@ suite('networked', function() {
 
       var templateChild = entity.querySelector('[template]');
       var result = templateChild.components.visible.attrValue;
-      
+
       assert.isFalse(result);
     }));
   });

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -77,7 +77,7 @@ suite('networked', function() {
       assert.equal(result, 'nid1');
     }));
 
-    test.only('retains networkId after component update', sinon.test(function() {
+    test('retains networkId after component update', sinon.test(function() {
       this.stub(naf.utils, 'createNetworkId').returns('nid-after-load');
 
       networked.init();


### PR DESCRIPTION
Changing component data directly is bad practice as it leads to internal inconsistencies in a-frame. 
For example, the network id may get clobbered if a-frame calls `updateComponents` after an asset timeout.