### PR TITLE
Fix error in easyrtc server when calling listen twice.

### DIFF
--- a/server/easyrtc-server.js
+++ b/server/easyrtc-server.js
@@ -16,7 +16,7 @@ var app = express();
 app.use(serveStatic('server/static', {'index': ['index.html']}));
 
 // Start Express http server
-var webServer = http.createServer(app).listen(port);
+var webServer = http.createServer(app);
 
 // Start Socket.io so it attaches itself to Express server
 var socketServer = socketIo.listen(webServer, {"log level":1});


### PR DESCRIPTION
I recently upgraded node to v9.3.0 and started receiving this error: 

```
Error [ERR_SERVER_ALREADY_LISTEN]: Listen method has been called more than once without closing.
    at Server.listen (net.js:1458:11)
    at Object.<anonymous> (/Users/rlong/workspace/networked-aframe/server/easyrtc-server.js:78:11)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
    at startup (bootstrap_node.js:194:16)
    at bootstrap_node.js:618:3
```

I removed the duplicate call to `.listen()` and it seems to have fixed this issue.
  