### PR TITLE
Emit sound source and fix audio output for safari

### DIFF
--- a/src/components/networked-audio-source.js
+++ b/src/components/networked-audio-source.js
@@ -47,13 +47,19 @@ AFRAME.registerComponent('networked-audio-source', {
       }
       if(newStream) {
         // Chrome seems to require a MediaStream be attached to an AudioElement before AudioNodes work correctly
-        this.audioEl = new Audio();
-        this.audioEl.setAttribute("autoplay", "autoplay");
-        this.audioEl.setAttribute("playsinline", "playsinline");
-        this.audioEl.srcObject = newStream;
-        this.audioEl.volume = 0; // we don't actually want to hear audio from this element
+        // We don't want to do this in other browsers, particularly in Safari, which actually plays the audio despite
+        // setting the volume to 0.
+        if (/chrome/i.test(navigator.userAgent)) {
+          this.audioEl = new Audio();
+          this.audioEl.setAttribute("autoplay", "autoplay");
+          this.audioEl.setAttribute("playsinline", "playsinline");
+          this.audioEl.srcObject = newStream;
+          this.audioEl.volume = 0; // we don't actually want to hear audio from this element
+        }
 
-        this.sound.setNodeSource(this.sound.context.createMediaStreamSource(newStream));
+        const soundSource = this.sound.context.createMediaStreamSource(newStream); 
+        this.sound.setNodeSource(soundSource);
+        this.el.emit('sound-source-set', { soundSource });
       }
       this.stream = newStream;
     }


### PR DESCRIPTION
This helps solve two issues with Safari:
1. If you want to use the audio stream in Safari, e.g to visualize the audio, you need access to the MediaStreamSource that networked-aframe creates, since Safari will play garbled audio if you try to `createMediaStreamSource` twice on the same stream. This PR adds an `sound-source-set` event that passes the sound source to any consumers.
2. Safari on iOS would play audio from the hidden `Audio` node that we were creating as a workaround for Chrome. This change applies the workaround to chrome browsers only.