### PR TITLE
Allow adapters to return a value from connect()

### DIFF
--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -51,7 +51,7 @@ class NetworkConnection {
     );
     this.adapter.setRoomOccupantListener(this.occupantsReceived.bind(this));
 
-    this.adapter.connect();
+    return this.adapter.connect();
   }
 
   onConnect(callback) {

--- a/src/components/networked-scene.js
+++ b/src/components/networked-scene.js
@@ -34,7 +34,7 @@ AFRAME.registerComponent('networked-scene', {
     if (this.hasOnConnectFunction()) {
       this.callOnConnect();
     }
-    NAF.connection.connect(this.data.serverURL, this.data.app, this.data.room, this.data.audio);
+    return NAF.connection.connect(this.data.serverURL, this.data.app, this.data.room, this.data.audio);
   },
 
   checkDeprecatedProperties: function() {


### PR DESCRIPTION
Ideally this should be a promise that resolves when connect has completed, but this could be formalized later.