### PR TITLE
(WIP) Do not ignore first update, even when it is not a full sync.

### DIFF
--- a/src/ComponentHelper.js
+++ b/src/ComponentHelper.js
@@ -20,7 +20,7 @@ module.exports.gatherComponentsData = function(el, schemaComponents) {
           var data = element.property ? attributeData[element.property] : attributeData;
           compsData[childKey] = AFRAME.utils.clone(data);
         } else {
-          // NAF.log.write('ComponentHelper.gatherComponentsData: Could not find component ' + element.component + ' on child ', child, child.components);
+          NAF.log.warn('ComponentHelper.gatherComponentsData: Could not find component ' + element.component + ' on child ', child, child.components);
         }
       }
     }

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -64,8 +64,14 @@ class NetworkEntities {
 
     if (this.hasEntity(networkId)) {
       this.entities[networkId].emit('networkUpdate', {entityData: entityData}, false);
-    } else if (!isCompressed && this.isFullSync(entityData)) {
+    } else if (!isCompressed) {
+      if (!this.isFullSync(entityData)){
+        this.warnForIncompleteFirstUpdate(entityData, networkId);
+      }
       this.receiveFirstUpdateFromEntity(entityData);
+    } else {
+      console.error(`Recieved compressed update from ${networkId} for entity we haven't created yet:`);
+      console.error(entityData);
     }
   }
 
@@ -73,6 +79,16 @@ class NetworkEntities {
     var numSentComps = Object.keys(entityData.components).length;
     var numTemplateComps = NAF.schemas.getComponents(entityData.template).length;
     return numSentComps === numTemplateComps;
+  }
+
+  warnForIncompleteFirstUpdate(entityData, networkId){
+    const numSentComps = Object.keys(entityData.components).length;
+    const numTemplateComps = NAF.schemas.getComponents(entityData.template).length;
+    console.warn(`Expected ${numTemplateComps} from ${networkId} for first update. Only received ${numSentComps}.`);
+    console.warn("Received:");
+    console.warn(entityData.components);
+    console.warn("Expected:");
+    console.warn(NAF.schemas.getComponents(entityData.template));
   }
 
   receiveFirstUpdateFromEntity(entityData) {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -70,8 +70,7 @@ class NetworkEntities {
       }
       this.receiveFirstUpdateFromEntity(entityData);
     } else {
-      console.error(`Recieved compressed update from ${networkId} for entity we haven't created yet:`);
-      console.error(entityData);
+      console.error(`Recieved compressed update from ${networkId} for entity we haven't created yet:`, entityData);
     }
   }
 
@@ -84,11 +83,9 @@ class NetworkEntities {
   warnForIncompleteFirstUpdate(entityData, networkId){
     const numSentComps = Object.keys(entityData.components).length;
     const numTemplateComps = NAF.schemas.getComponents(entityData.template).length;
-    console.warn(`Expected ${numTemplateComps} from ${networkId} for first update. Only received ${numSentComps}.`);
-    console.warn("Received:");
-    console.warn(entityData.components);
-    console.warn("Expected:");
-    console.warn(NAF.schemas.getComponents(entityData.template));
+    console.warn(`Only received ${numSentComps} of ${numTemplateComps} expected component updates from ${networkId}'s first update.`,
+                 "Expected:", NAF.schemas.getComponents(entityData.template),
+                 "Received:", entityData.components);
   }
 
   receiveFirstUpdateFromEntity(entityData) {


### PR DESCRIPTION
**WIP**
If the first update for a network entity is not a full sync, then the update was ignored entirely. Then, subsequent updates would only include dirty component data, which means a full sync would never come and the network entity was never created and added to the scene.

This is a problem in the case when a schema declares a component that needs to be synced by selector, but that component is not available before the first update. This can happen, for instance, if the component in question is added to an entity that is inflated via [`gltf-model-plus`](https://github.com/mozilla/mr-social-client/blob/master/src/components/gltf-model-plus.js) with `inflate: true;`, but the client takes longer to load the gltf model than to send the first update for the entity whose `networked` component uses the schema. 

This is not the only way this can occur. Any time an entity's `networked` component specifies a schema that includes components that are missing from the entity, the first update will be ignored. 

This fix works correctly as long as it's OK for the remote client that receives the incomplete update to create the networked entity for the update according to the template, filling in default values for the components that were missing from the update. This may only be a problem if the app developer does not expect the missing components to be added locally at all, and their presence on the remote client is undesirable, due to the following point: Once the local client adds the components that were originally missing from the networked entity's schema, that component data will be recognized as dirty, and be passed to the remote client. It seems like an anti-pattern to me for the app developer to use templates this way, but if this ends up being a problem then we may want to have a smarter strategy about what to do when the first update for a network entity is missing component data that should be there according to the schema.