### PR TITLE
Change package.json to expose index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.1",
   "description": "A web framework for building multi-user virtual reality experiences.",
   "homepage": "",
-  "main": "dist/networked-aframe.js",
+  "main": "src/index.js",
   "author": "Hayden Lee <haydenjameslee@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
networked-aframe currently exposes the bundled/dist version of networked-aframe in package.json. Including the bundled version in a webpack project makes it so the source map generated points to the sourcemap of the bundle and not the individual files of the library. The downsides of doing this is that all consumers of the library need to have ES2015 support. I think it's safe now to require ES2015 as most developers are using Babel if they are requiring the npm package.