### PR TITLE
buffered interpolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
-    "buffered-interpolation": "^0.2.3",
+    "buffered-interpolation": "^0.2.4",
     "easyrtc": "1.1.0",
     "express": "^4.10.7",
     "serve-static": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
-    "buffered-interpolation": "^0.0.2",
+    "buffered-interpolation": "^0.1.0",
     "easyrtc": "1.1.0",
     "express": "^4.10.7",
     "serve-static": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
+    "buffered-interpolation": "^0.0.2",
     "easyrtc": "1.1.0",
     "express": "^4.10.7",
-    "aframe-lerp-component": "^1.1.0",
     "serve-static": "^1.8.0",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
-    "buffered-interpolation": "^0.2.1",
+    "buffered-interpolation": "^0.2.3",
     "easyrtc": "1.1.0",
     "express": "^4.10.7",
     "serve-static": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
-    "buffered-interpolation": "^0.1.0",
+    "buffered-interpolation": "^0.2.1",
     "easyrtc": "1.1.0",
     "express": "^4.10.7",
     "serve-static": "^1.8.0",

--- a/src/ComponentHelper.js
+++ b/src/ComponentHelper.js
@@ -69,7 +69,10 @@ module.exports.findDirtyComponents = function(el, syncedComps, cachedData) {
     }
 
     var oldCompData = cachedData[compKey];
-    if (!deepEqual(oldCompData, newCompData)) {
+
+    if (schema.requiresNetworkUpdate && schema.requiresNetworkUpdate(oldCompData, newCompData)){
+      dirtyComps.push(schema);
+    } else if (!schema.requiresNetworkUpdate && !deepEqual(oldCompData, newCompData)) {
       dirtyComps.push(schema);
     }
   }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -325,7 +325,7 @@ AFRAME.registerComponent('networked', {
     var buffer = null;
     var interpolationBuffer = this.interpolationBuffers.find((item) => item.el === el);
     if (!interpolationBuffer) {
-      buffer = new InterpolationBuffer();
+      buffer = new InterpolationBuffer(InterpolationBuffer.MODE_LERP, 0.1);
       this.interpolationBuffers.push({ buffer: buffer, el: el });
     } else {
       buffer = this.interpolationBuffers.find((item) => item.el === el).buffer;

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -21,6 +21,9 @@ AFRAME.registerComponent('networked', {
     this.conversionEuler = new THREE.Euler();
     this.conversionEuler.order = "YXZ";
     this.interpolationBuffers = [];
+    this.bufferPosition = new THREE.Vector3();
+    this.bufferQuaternion = new THREE.Quaternion();
+    this.bufferScale = new THREE.Vector3();
 
     var wasCreatedByNetwork = this.wasCreatedByNetwork();
 
@@ -330,14 +333,14 @@ AFRAME.registerComponent('networked', {
 
     switch(key) {
       case "position":
-        buffer.setPosition(new THREE.Vector3(data.x, data.y, data.z));
+        buffer.setPosition(this.bufferPosition.set(data.x, data.y, data.z));
         break;
       case "rotation":
         this.conversionEuler.set(DEG2RAD * data.x, DEG2RAD * data.y, DEG2RAD * data.z);
-        buffer.setQuaternion(new THREE.Quaternion().setFromEuler(this.conversionEuler));
+        buffer.setQuaternion(this.bufferQuaternion.setFromEuler(this.conversionEuler));
         break;
       case "scale":
-        buffer.setScale(new THREE.Vector3(data.x, data.y, data.z));
+        buffer.setScale(this.bufferScale.set(data.x, data.y, data.z));
         break;
       default:
         el.setAttribute(key, data);

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -1,4 +1,4 @@
-/* global AFRAME, NAF */
+/* global AFRAME, NAF, THREE */
 var componentHelper = require('../ComponentHelper');
 var Compressor = require('../Compressor');
 var InterpolationBuffer = require('buffered-interpolation');

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-// Dependencies
-require('aframe-lerp-component');
-
 // Global vars and functions
 require('./NafIndex.js');
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,3 +126,7 @@ module.exports.isMine = function(entity) {
 
   throw new Error("isMine() must be called on an entity or child of an entity with the [networked] component.");
 };
+
+module.exports.almostEqualVec3 = function(u, v, epsilon) {
+  return Math.abs(u.x-v.x)<epsilon && Math.abs(u.y-v.y)<epsilon && Math.abs(u.z-v.z)<epsilon;
+};

--- a/tests/unit/networked_remote.test.js
+++ b/tests/unit/networked_remote.test.js
@@ -99,21 +99,24 @@ suite('networked_remote', function() {
       }
 
       component.networkUpdate(entityData);
+      component.tick(15, 15);
 
-      var components = el.components;
-      assert.equal(components['position'].data.x, 10, 'Position');
-      assert.equal(components['position'].data.y, 20, 'Position');
-      assert.equal(components['position'].data.z, 30, 'Position');
+      setTimeout(()=> {
+        var components = el.components;
+        assert.equal(components['position'].data.x, 10, 'Position');
+        assert.equal(components['position'].data.y, 20, 'Position');
+        assert.equal(components['position'].data.z, 30, 'Position');
 
-      assert.equal(components['rotation'].data.x, 40, 'Rotation');
-      assert.equal(components['rotation'].data.y, 30, 'Rotation');
-      assert.equal(components['rotation'].data.z, 20, 'Rotation');
+        assert.equal(components['rotation'].data.x, 40, 'Rotation');
+        assert.equal(components['rotation'].data.y, 30, 'Rotation');
+        assert.equal(components['rotation'].data.z, 20, 'Rotation');
 
-      assert.equal(components['scale'].data.x, 1, 'Scale');
-      assert.equal(components['scale'].data.y, 1, 'Scale');
-      assert.equal(components['scale'].data.z, 1, 'Scale');
+        assert.equal(components['scale'].data.x, 1, 'Scale');
+        assert.equal(components['scale'].data.y, 1, 'Scale');
+        assert.equal(components['scale'].data.z, 1, 'Scale');
 
-      assert.equal(components['visible'].data, true, 'Visible');
+        assert.equal(components['visible'].data, true, 'Visible');
+      }, 1);
     }));
 
     test('sets correct uncompressed data with child components', sinon.test(function() {
@@ -184,21 +187,24 @@ suite('networked_remote', function() {
       ];
 
       component.networkUpdate(compressed);
+      component.tick(15, 15);
 
-      var components = el.components;
-      assert.equal(components['position'].data.x, 10, 'Position');
-      assert.equal(components['position'].data.y, 20, 'Position');
-      assert.equal(components['position'].data.z, 30, 'Position');
+      setTimeout(()=> {
+        var components = el.components;
+        assert.equal(components['position'].data.x, 10, 'Position');
+        assert.equal(components['position'].data.y, 20, 'Position');
+        assert.equal(components['position'].data.z, 30, 'Position');
 
-      assert.equal(components['rotation'].data.x, 40, 'Rotation');
-      assert.equal(components['rotation'].data.y, 30, 'Rotation');
-      assert.equal(components['rotation'].data.z, 20, 'Rotation');
+        assert.equal(components['rotation'].data.x, 40, 'Rotation');
+        assert.equal(components['rotation'].data.y, 30, 'Rotation');
+        assert.equal(components['rotation'].data.z, 20, 'Rotation');
 
-      assert.equal(components['scale'].data.x, 1, 'Scale');
-      assert.equal(components['scale'].data.y, 1, 'Scale');
-      assert.equal(components['scale'].data.z, 1, 'Scale');
+        assert.equal(components['scale'].data.x, 1, 'Scale');
+        assert.equal(components['scale'].data.y, 1, 'Scale');
+        assert.equal(components['scale'].data.z, 1, 'Scale');
 
-      assert.equal(components['visible'].data, true, 'Visible');
+        assert.equal(components['visible'].data, true, 'Visible');
+      }, 1);
     }));
   });
 });

--- a/tests/unit/networked_remote.test.js
+++ b/tests/unit/networked_remote.test.js
@@ -58,31 +58,6 @@ suite('networked_remote', function() {
       assert.isOk(templateChild);
     });
 
-    test('does not add lerp when created by network', function() {
-      var result = el.hasAttribute('lerp');
-
-      assert.isFalse(result);
-    });
-
-    test('adds lerp when created by network', function() {
-      el.firstUpdateData = {test: true};
-      component.init();
-
-      var result = el.hasAttribute('lerp');
-
-      assert.isTrue(result);
-    });
-
-    test('does not add lerp if lerp option off', function() {
-      naf.options.useLerp = false;
-      el.removeAttribute('lerp');
-
-      component.init();
-      var result = el.hasAttribute('lerp');
-
-      assert.isFalse(result);
-    });
-
     test('updates root immediately', sinon.test(function() {
       this.stub(component, 'networkUpdate');
       var testData = {test: "testing"};


### PR DESCRIPTION
This is different take on https://github.com/networked-aframe/networked-aframe/pull/124 
It uses a new package I wrote: https://github.com/InfiniteLee/buffered-interpolation

It has 3 advantages:

1. It uses a (configurable) buffer that provides some network jitter protection and also makes sure that updates received continuously are not lost (e.g. lerping from A -> B -> C will no longer "skip" B if C is received before B is reached).
2. It reuses the last received network update if no updates are sent. This prevents the issue where the lerp duration is determined by how long ago the last update was received.
3. It has functionality to use hermite interpolation, if we decide to enable syncing of a velocity component. This should work very well for physics enabled objects, ballistic projectiles, frisbees... etc. (Coming in a future PR). 