### PR TITLE
Correct networked entity deletion event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ List of events:
 | clientConnected | Fired when another client connects to you | `evt.detail.clientId` - ClientId of connecting client |
 | clientDisconnected | Fired when another client disconnects from you | `evt.detail.clientId` - ClientId of disconnecting client |
 | entityCreated | Fired when a networked entity is created | `evt.detail.el` - new entity |
-| entityDeleted | Fired when a networked entity is deleted | `evt.detail.networkId` - networkId of deleted entity |
+| entityRemoved | Fired when a networked entity is deleted | `evt.detail.networkId` - networkId of deleted entity |
 
 The following events are fired on the `networked` component. See the [toggle-ownership component](./server/static/js/toggle-ownership.component.js) for examples.
 


### PR DESCRIPTION
The event type that is fired is `'entityRemoved'`

https://github.com/networked-aframe/networked-aframe/blob/4c270ff0dc5b6429293c110141697fa326fdef0b/src/components/networked.js#L441