### PR TITLE
Assume requiresNetworkUpdate is a second order function

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -55,7 +55,7 @@ AFRAME.registerComponent('networked', {
     this.syncData = {};
     this.componentSchemas =  NAF.schemas.getComponents(this.data.template);
     this.cachedElements = new Array(this.componentSchemas.length);
-    this.networkUpdatePredicates = this.componentSchemas.map(x => x.requiresNetworkUpdate || defaultRequiresUpdate());
+    this.networkUpdatePredicates = this.componentSchemas.map(x => (x.requiresNetworkUpdate && x.requiresNetworkUpdate()) || defaultRequiresUpdate());
 
     // Fill cachedElements array with null elements
     this.invalidateCachedElements();


### PR DESCRIPTION
This PR changes the contract for requiresNetworkUpdate custom predicate on the schema to now be a second order function, like the default, so it can create component instance-level bindings for state (like as is done in the default for the previous value.)