### PR TITLE
A simple take on networked entity persistence

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -50,7 +50,8 @@ class NetworkEntities {
     var networkData = {
       template: entityData.template,
       owner: entityData.owner,
-      networkId: entityData.networkId
+      networkId: entityData.networkId,
+      persistent: entityData.persistent
     };
 
     entity.setAttribute('networked', networkData);

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -138,8 +138,14 @@ class NetworkEntities {
     for (var id in this.entities) {
       var entityOwner = NAF.utils.getNetworkOwner(this.entities[id]);
       if (entityOwner == clientId) {
-        var entity = this.removeEntity(id);
-        entityList.push(entity);
+        let persists
+        if (this.entities[id].getAttribute('networked').persistent) {
+          persists = NAF.utils.takeOwnership(this.entities[id]);
+        }
+        if (!persists) {
+          var entity = this.removeEntity(id);
+          entityList.push(entity);
+        }
       }
     }
     return entityList;

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -304,6 +304,7 @@ AFRAME.registerComponent('networked', {
     syncData.owner = data.owner;
     syncData.lastOwnerTime = this.lastOwnerTime;
     syncData.template = data.template;
+    syncData.persistent = data.persistent;
     syncData.parent = this.getParentId();
     syncData.components = components;
     syncData.isFirstSync = !!isFirstSync;
@@ -355,6 +356,9 @@ AFRAME.registerComponent('networked', {
       this.el.emit(this.OWNERSHIP_CHANGED, this.onOwnershipChangedEvent);
 
       this.el.setAttribute('networked', { owner: entityData.owner });
+    }
+    if (this.data.persistent !== entityData.persistent) {
+      this.el.setAttribute('networked', 'persistent', entityData.persistent);
     }
     this.updateComponents(entityData.components);
   },

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -21,6 +21,7 @@ AFRAME.registerComponent('networked', {
   schema: {
     template: {default: ''},
     attachTemplateToLocal: { default: true },
+    persistent: { default: false },
 
     networkId: {default: ''},
     owner: {default: ''},


### PR DESCRIPTION
Sometimes you don't want an entity to be destroyed when its owner disconnects. This could be a model or drawing added to a scene by a user or a singleton object like a presentation controller.

This approach adds the `persistent` property to the `networked` component, and, on remote owner disconnect, attempts to take ownership of persistent entities rather than delete them. It's not the most efficient approach, as, in a room with multiple users, everyone races for ownership and the slowest wins. It is, however, achieved with minimal changes and should work even if the original owner crashes or otherwise disconnects unexpectedly.

If you're interested in this approach, I can add documentation and testing to this PR. If you're not, no sweat, just wanted to share what we're using. 