### PR TITLE
fixed networked-audio-source

### DIFF
--- a/examples/basic-audio.html
+++ b/examples/basic-audio.html
@@ -30,8 +30,8 @@
         <!-- Templates -->
 
         <!-- Avatar -->
-        <template id="avatar-template" networked-audio-source>
-          <a-entity class="avatar">
+        <template id="avatar-template">
+          <a-entity class="avatar" networked-audio-source>
             <a-sphere class="head"
               color="#ffffff"
               scale="0.45 0.5 0.4"


### PR DESCRIPTION
My apologies, I screwed this one up ... should have double checked.
The networked-audio-source belongs to the entity tag, not the template.