### PR TITLE
Fix getServerTime returning a string

### DIFF
--- a/src/adapters/naf-socketio-adapter.js
+++ b/src/adapters/naf-socketio-adapter.js
@@ -216,7 +216,7 @@ class SocketioAdapter {
   }
 
   getServerTime() {
-    return new Date() + this.avgTimeOffset;
+    return new Date().getTime() + this.avgTimeOffset;
   }
 }
 

--- a/src/adapters/naf-webrtc-adapter.js
+++ b/src/adapters/naf-webrtc-adapter.js
@@ -582,7 +582,7 @@ class WebrtcAdapter {
   }
 
   getServerTime() {
-    return new Date() + this.avgTimeOffset;
+    return new Date().getTime() + this.avgTimeOffset;
   }
 }
 


### PR DESCRIPTION
On Chrome and Firefox, `new Date() + this.avgTimeOffset` results in a date string with `avgTimeOffset` appended as a string to the end.

This pull request converts the date to a number, which ensures that addition happens numerically, ensuring that `getServerTime` returns a time number, as expected (as evidenced by comparing `getServerTime()` using less than and greater than elsewhere in the code)