### PR TITLE
components/networked.js: this.data can be undefined

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -405,6 +405,7 @@ AFRAME.registerComponent('networked', {
       return;
     }
 
+    // Hack to solve this bug: https://github.com/networked-aframe/networked-aframe/issues/200
     if (this.data === undefined) {
       return;
     }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -405,6 +405,10 @@ AFRAME.registerComponent('networked', {
       return;
     }
 
+    if (this.data === undefined) {
+      return;
+    }
+
     if (this.data.owner !== entityData.owner) {
       var wasMine = this.isMine();
       this.lastOwnerTime = entityData.lastOwnerTime;


### PR DESCRIPTION
Sometimes the `this.data` value is undefined if there is a high load of messages coming in, such as when a VR headset joins. This causes the other avatar to disappear from the screen, even though it still appears in the occupants array and the other player can still see this one.

Discussion in issue #200