### PR TITLE
Remove travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 Networked-Aframe
 =======
 
-<a href="https://travis-ci.org/networked-aframe/networked-aframe"><img src="https://img.shields.io/travis/networked-aframe/networked-aframe.svg" alt="Build Status"></a>
 <span class="badge-npmversion"><a href="https://npmjs.org/package/networked-aframe" title="View this project on NPM"><img src="https://img.shields.io/npm/v/networked-aframe.svg" alt="NPM version" /></a></span>
 <span class="badge-npmdownloads"><a href="https://npmjs.org/package/networked-aframe" title="View this project on NPM"><img src="https://img.shields.io/npm/dm/networked-aframe.svg" alt="NPM downloads" /></a></span>
 


### PR DESCRIPTION
I already removed the `.travis.yml` file in a previous commit.
See #237 to move to Github Actions.