### PR TITLE
properly cleanup audio element in networked-audio-source remove

### DIFF
--- a/src/components/networked-audio-source.js
+++ b/src/components/networked-audio-source.js
@@ -81,6 +81,13 @@ AFRAME.registerComponent('networked-audio-source', {
     if (this.stream) {
       this.sound.disconnect();
     }
+
+    if (this.audioEl) {
+      this.audioEl.pause();
+      this.audioEl.srcObject = null;
+      this.audioEl.load();
+      this.audioEl = null;
+    }
   },
 
   setupSound: function() {


### PR DESCRIPTION
Properly cleanup audio element in `networked-audio-source` remove function like we do for video in `networked-video-source` ([see code](https://github.com/networked-aframe/networked-aframe/blob/2c64d0dc7baff5b3ff9c2e83eb32545f7da34856/src/components/networked-video-source.js#L74-L76)).
This is to be sure that the resource is released.
In Chrome 92, there is now limits on WebMediaPlayers you can create. See
https://bugs.chromium.org/p/chromium/issues/detail?id=1232649
https://chromium-review.googlesource.com/c/chromium/src/+/2816118
I didn't encounter any issue myself, but I guess it doesn't hurt to properly release the audio element that way.