### PR TITLE
In the instructions, you forgot to copy the dist file

### DIFF
--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -60,10 +60,12 @@ Let's copy the example server that comes with networked-aframe into our project.
 # MacOS & Linux
 cp -r ./node_modules/networked-aframe/server/ ./server/
 cp -r ./node_modules/networked-aframe/examples/ ./examples/
+cp -r ./node_modules/networked-aframe/dist/ ./examples/dist/ /e
 
 # Windows
 robocopy .\node_modules\networked-aframe\server\ .\server\ /e
 robocopy .\node_modules\networked-aframe\examples\ .\examples\ /e
+robocopy .\node_modules\networked-aframe\dist\ .\examples\dist\ /e
 ```
 
 You'll now see another new folder: `server/`. Inside it you'll see `easyrtc-server.js` which is the server code.


### PR DESCRIPTION
Hi Vincent, I am starting a new local naf . Following the instructions, my basic example .html does not work because dist folder is not copied to installation folder. I have put the robocopy and cp command to fix it in this pull request.