### PR TITLE
update engines to node>=16 npm>=7

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "webvr"
   ],
   "engines": {
-    "node": ">= 8.10.0",
-    "npm": ">= 4.0.5"
+    "node": ">=16",
+    "npm": ">=7"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Update engines to node>=16 npm>=7 so glitch selects node v16.12.0 npm 7.20.6 environment instead of node 10.

The new package-lock.json lockfile v2 format requires npm >= 7.