### PR TITLE
Force streams to be removed when client disconnects (fixes #321)

### DIFF
--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -25,7 +25,6 @@ class EasyRtcAdapter extends NoOpAdapter {
 
     this.easyrtc.setPeerClosedListener((clientId) => {
       delete this.remoteClients[clientId];
-      this.closeStreamConnection(clientId);
     });
   }
 
@@ -309,7 +308,7 @@ class EasyRtcAdapter extends NoOpAdapter {
     this.easyrtc.setStreamAcceptor(this.setMediaStream.bind(this));
 
     this.easyrtc.setOnStreamClosed(function(clientId, stream, streamName) {
-      delete this.mediaStreams[clientId][streamName];
+      delete that.mediaStreams[clientId][streamName];
     });
 
     if (that.easyrtc.audioEnabled || that.easyrtc.videoEnabled) {

--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -25,6 +25,7 @@ class EasyRtcAdapter extends NoOpAdapter {
 
     this.easyrtc.setPeerClosedListener((clientId) => {
       delete this.remoteClients[clientId];
+      this.closeStreamConnection(clientId);
     });
   }
 


### PR DESCRIPTION
Added a manual (force) close of streams whenever a peer disconnects. Currently this is not handled by the openrtc lib.