### PR TITLE
Fix regression introduced in 0.9.0 that failed to remove mediaStreams properly

### DIFF
--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -225,7 +225,7 @@ class EasyRtcAdapter extends NoOpAdapter {
     const pendingMediaRequests = this.pendingMediaRequests.get(clientId); // return undefined if there is no entry in the Map
     const clientMediaStreams = this.mediaStreams[clientId] = this.mediaStreams[clientId] || {};
 
-    if (streamName === 'default') {
+    if (streamName === "default") {
       // Safari doesn't like it when you use a mixed media stream where one of the tracks is inactive, so we
       // split the tracks into two streams.
       // Add mediaStreams audio streamName alias
@@ -308,7 +308,16 @@ class EasyRtcAdapter extends NoOpAdapter {
     this.easyrtc.setStreamAcceptor(this.setMediaStream.bind(this));
 
     this.easyrtc.setOnStreamClosed(function(clientId, stream, streamName) {
-      delete this.mediaStreams[clientId][streamName];
+      if (streamName === "default") {
+        delete that.mediaStreams[clientId].audio;
+        delete that.mediaStreams[clientId].video;
+      } else {
+        delete that.mediaStreams[clientId][streamName];
+      }
+
+      if (Object.keys(that.mediaStreams[clientId]).length === 0) {
+        delete that.mediaStreams[clientId];
+      }
     });
 
     if (that.easyrtc.audioEnabled || that.easyrtc.videoEnabled) {

--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -25,6 +25,14 @@ class EasyRtcAdapter extends NoOpAdapter {
 
     this.easyrtc.setPeerClosedListener((clientId) => {
       delete this.remoteClients[clientId];
+      const pendingMediaRequests = this.pendingMediaRequests.get(clientId);
+      if (pendingMediaRequests) {
+        const msg = "The user disconnected before the media stream was resolved.";
+        Object.keys(pendingMediaRequests).forEach((streamName) => {
+         pendingMediaRequests[streamName].reject(msg);
+        });
+        this.pendingMediaRequests.delete(clientId);
+      }
     });
   }
 


### PR DESCRIPTION
This closes #321 