### PR TITLE
Add a spawned persistent spheres (peer to peer) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ Subscribe and unsubscribe callbacks to network messages specified by `dataType`.
 | Parameter | Description
 | -------- | -----------
 | clientId | ClientId to send this data to
-| dataType  | String to identify a network message. `u` is a reserved data type, don't use it pls
-| callback  | Function to be called when message of type `dataType` is received. Parameters: `function(senderId, dataType, data, targetId)`
+| dataType  | String to identify a network message. `u` (Update), `um` (UpdateMulti) and `r` (Remove) are reserved data types, don't use them please
+| callback  | Function to be called when message of type `dataType` is received. Parameters: `function(senderId, dataType, data, targetObj)` With the easyrtc adapter `targetObj` can be `{targetRoom: 'roomId'}` when broadcasting a message or `{targetEasyrtcid: 'targetId'}` when sending a message to a specific participant. With the janus adapter, senderId is always null and `targetObj` is more a `source` parameter and generally equals to "janus-event".
 | data | Object to be sent to all other clients
 
 

--- a/examples/basic-persistent.html
+++ b/examples/basic-persistent.html
@@ -66,7 +66,7 @@
 
         <!-- Templates -->
         <template id="sphere-template">
-          <a-entity geometry="primitive: sphere" material="color: red" color-changer></a-entity>
+          <a-entity class="raycastable" geometry="primitive: sphere" material="color: red" color-changer></a-entity>
         </template>
 
         <!-- Avatar -->
@@ -120,7 +120,7 @@
         ></a-sphere>
       </a-entity>
 
-      <a-entity class="raycastable" id="sphere" networked="template:#sphere-template;networkId:sphere;persistent:true;owner:scene"></a-entity>
+      <a-entity id="sphere" networked="template:#sphere-template;networkId:sphere;persistent:true;owner:scene"></a-entity>
       <!--
         Specifying a owner that isn't a real participant is used so that the
         participant joining the room won't send this entity because not the

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,6 +37,14 @@
       </span>
     </div>
     <div>
+      <a href="persistent-peer-to-peer.html">Spawned persistent spheres</a>
+      <span>
+        Similar to the above example but with spawned spheres.
+        The spheres are kept in the room if there is at least one participant remaining in the room.
+        The persistence is done peer to peer. All spheres are lost if all participants leave the room.
+      </span>
+    </div>
+    <div>
       <a href="basic-4.html">4-in-one</a>
       <span>Opens the basic example 4 times on one page using iframes</span>
     </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -30,21 +30,6 @@
       <span>Simple avatars with synced color</span>
     </div>
     <div>
-      <a href="basic-persistent.html">Persistent sphere</a>
-      <span>
-        Simple sphere that changes color on click. The color is synced between participants.
-        This is an example of a persistent entity defined in the html.
-      </span>
-    </div>
-    <div>
-      <a href="persistent-peer-to-peer.html">Spawned persistent spheres</a>
-      <span>
-        Similar to the above example but with spawned spheres.
-        The spheres are kept in the room if there is at least one participant remaining in the room.
-        The persistence is done peer to peer. All spheres are lost if all participants leave the room.
-      </span>
-    </div>
-    <div>
       <a href="basic-4.html">4-in-one</a>
       <span>Opens the basic example 4 times on one page using iframes</span>
     </div>
@@ -87,6 +72,21 @@
     <div>
       <a href="ownership-transfer.html">Ownership Transfer</a>
       <span>Demonstrates transfering ownership of entities</span>
+    </div>
+    <div>
+      <a href="basic-persistent.html">Persistent sphere</a>
+      <span>
+        Simple sphere that changes color on click. The color is synced between participants.
+        This is an example of a persistent entity defined in the html.
+      </span>
+    </div>
+    <div>
+      <a href="persistent-peer-to-peer.html">Spawned persistent spheres</a>
+      <span>
+        Similar to the above example but with spawned spheres.
+        The spheres are kept in the room if there is at least one participant remaining in the room.
+        The persistence is done peer to peer. All spheres are lost if all participants leave the room.
+      </span>
     </div>
     <div>
       <a href="adapter-test/">Adapter Test</a>

--- a/examples/js/persistent-p2p.component.js
+++ b/examples/js/persistent-p2p.component.js
@@ -1,0 +1,87 @@
+/* global AFRAME, NAF */
+AFRAME.registerComponent('persistent-p2p', {
+
+  init: function() {
+    this.onConnected = this.onConnected.bind(this);
+    this.sendPersistentEntityCreated = this.sendPersistentEntityCreated.bind(this);
+
+    if (NAF.clientId) {
+      this.onConnected();
+    } else {
+      document.body.addEventListener('connected', this.onConnected, false);
+    }
+  },
+
+  onConnected: function() {
+    const receiveData = (_senderId, _dataType, data) => {
+      if (data.eventType === 'persistentEntityCreated') {
+        const el = document.createElement('a-entity');
+        this.el.sceneEl.appendChild(el);
+        el.setAttribute('networked', {
+            networkId: data.networkId,
+            template: data.template,
+            persistent: true,
+            owner: 'scene'
+        });
+        // If we receive a {persistent: true, isFirstSync: true} NAF `u` message before the
+        // persistentEntityCreated message, the NAF message is stored in
+        // NAF.entities._persistentFirstSyncs waiting the entity to be created.
+        // After creating the entity like we just did above, we need to call
+        // applyPersistentFirstSync to consume the received data to really
+        // initialize the networked component, otherwise it won't show.
+        NAF.utils.getNetworkedEntity(el).then((networkedEl) => {
+          networkedEl.components.networked.applyPersistentFirstSync();
+        });
+      }
+    }
+
+    NAF.connection.subscribeToDataChannel('events', receiveData);
+
+    // The persistentEntityCreated event is emitted by the spawner-persistent component.
+    // Broadcast a persistentEntityCreated message to everyone in the room.
+    document.body.addEventListener('persistentEntityCreated', this.sendPersistentEntityCreated, false);
+
+    // Note that when a participant leave the room, the other participants take ownership of the persistent entities of the left participant,
+    // see the code in the NetworkEntities.removeEntitiesOfClient function for details.
+
+    // When a new participant enter the room, send the persistentEntityCreated
+    // message for each persistent entity I own.
+    // Sending the networked data are done by NAF already with the same logic.
+    document.body.addEventListener('clientConnected', (evt) => {
+      const targetClientId = evt.detail.clientId;
+      for (let id in NAF.entities.entities) {
+        if (NAF.entities.entities[id]) {
+          const networkedComponent = NAF.entities.entities[id].components.networked;
+          const networkedData = networkedComponent.data;
+          if (networkedData.persistent && networkedData.owner && networkedComponent.isMine()) {
+            const data = {
+              eventType: 'persistentEntityCreated',
+              networkId: networkedData.networkId,
+              template: networkedData.template
+            };
+            NAF.connection.sendDataGuaranteed(targetClientId, 'events', data);
+          }
+        }
+      }
+    });
+
+    document.body.removeEventListener('connected', this.onConnected, false);
+  },
+
+  sendPersistentEntityCreated: function(evt) {
+    const el = evt.detail.el;
+    NAF.utils.getNetworkedEntity(el).then((networkedEl) => {
+      if (NAF.connection.isConnected()) {
+        const networkedData = networkedEl.components.networked.data;
+        const data = {
+          eventType: 'persistentEntityCreated',
+          networkId: networkedData.networkId,
+          template: networkedData.template
+        };
+        NAF.connection.broadcastDataGuaranteed('events', data);
+      }
+    });
+  }
+});
+
+

--- a/examples/js/spawner-persistent.component.js
+++ b/examples/js/spawner-persistent.component.js
@@ -1,0 +1,25 @@
+/* global AFRAME, NAF */
+AFRAME.registerComponent('spawner-persistent', {
+  schema: {
+    template: { default: '' },
+    keyCode: { default: 32 }
+  },
+
+  init: function() {
+    this.onKeyUp = this.onKeyUp.bind(this);
+    document.addEventListener("keyup", this.onKeyUp);
+  },
+
+  onKeyUp: function(e) {
+    if (this.data.keyCode === e.keyCode) {
+      const el = document.createElement('a-entity');
+      this.el.sceneEl.appendChild(el);
+      el.setAttribute('position', this.el.getAttribute('position'));
+      el.setAttribute('networked', {persistent: true, template: this.data.template});
+      NAF.utils.getNetworkedEntity(el).then((networkedEl) => {
+        document.body.dispatchEvent(new CustomEvent('persistentEntityCreated', {detail: {el: el}}));
+      });
+    }
+  }
+});
+

--- a/examples/persistent-peer-to-peer.html
+++ b/examples/persistent-peer-to-peer.html
@@ -1,0 +1,189 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Spawned persistent spheres — Networked-Aframe</title>
+    <meta name="description" content="Dev Example — Networked-Aframe">
+
+    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <script src="/dist/networked-aframe.js"></script>
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate("#avatar-template")) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        if (!NAF.schemas.hasTemplate("#sphere-template")) {
+          NAF.schemas.add({
+            template: '#sphere-template',
+            components: [
+              "position",
+              {
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      }
+    </script>
+
+    <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
+    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
+    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="/js/spawn-in-circle.component.js"></script>
+    <script src="/js/color-changer.component.js"></script>
+    <script src="/js/spawner-persistent.component.js"></script>
+    <script src="/js/persistent-p2p.component.js"></script>
+    <!--
+      The spawner-persistent and persistent-p2p components go together,
+      spawner-persistent is set on the player entity,
+      persistent-p2p on the a-scene entity.
+      The persistent-p2p component handle the logic of keeping the persistent entities peer to peer.
+      The spheres are kept in the room if there is at least one participant remaining in the room.
+    -->
+    <link rel="stylesheet" type="text/css" href="/css/style.css" />
+  </head>
+  <body>
+    <a-scene
+      cursor="rayOrigin: mouse"
+      raycaster="objects:.raycastable"
+      persistent-p2p
+      networked-scene="
+        room: persistent-peer-to-peer;
+        debug: true;
+        adapter: wseasyrtc"
+    >
+      <a-assets>
+
+        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+
+        <!-- Templates -->
+        <template id="sphere-template">
+          <a-entity class="raycastable" geometry="primitive: sphere" material="color: red" color-changer></a-entity>
+        </template>
+
+        <!-- Avatar -->
+        <template id="avatar-template">
+          <a-entity class="avatar">
+            <a-sphere class="head"
+              scale="0.45 0.5 0.4"
+            ></a-sphere>
+            <a-entity class="face"
+              position="0 0.05 0"
+            >
+              <a-sphere class="eye"
+                color="#efefef"
+                position="0.16 0.1 -0.35"
+                scale="0.12 0.12 0.12"
+              >
+                <a-sphere class="pupil"
+                  color="#000"
+                  position="0 0 -1"
+                  scale="0.2 0.2 0.2"
+                ></a-sphere>
+              </a-sphere>
+              <a-sphere class="eye"
+                color="#efefef"
+                position="-0.16 0.1 -0.35"
+                scale="0.12 0.12 0.12"
+              >
+                <a-sphere class="pupil"
+                  color="#000"
+                  position="0 0 -1"
+                  scale="0.2 0.2 0.2"
+                ></a-sphere>
+              </a-sphere>
+            </a-entity>
+          </a-entity>
+        </template>
+
+        <!-- /Templates -->
+      </a-assets>
+
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        spawner-persistent="template:#sphere-template"
+        wasd-controls look-controls
+        >
+        <a-sphere class="head"
+          visible="false"
+          random-color
+        ></a-sphere>
+      </a-entity>
+
+      <a-entity position="0 0 0"
+        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
+        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
+
+      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
+      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
+
+      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
+      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+    </a-scene>
+
+    <div class="controls">
+      <p>Press space to spawn a sphere that will persist even if you leave the room at the condition there is a participant that stay in the room.</p>
+    </div>
+
+    <!-- GitHub Corner. -->
+    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      </svg>
+    </a>
+    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+    </style>
+
+    <script>
+      // On mobile remove elements that are resource heavy
+      var isMobile = AFRAME.utils.device.isMobile();
+
+      if (isMobile) {
+        var particles = document.getElementById('particles');
+        particles.parentNode.removeChild(particles);
+      }
+    </script>
+
+    <script>
+      // Define custom schema for syncing avatar color, set by random-color
+      // NAF.schemas.add({
+      //   template: '#avatar-template',
+      //   components: [
+      //     'position',
+      //     'rotation',
+      //     {
+      //       selector: '.head',
+      //       component: 'material',
+      //       property: 'color'
+      //     }
+      //   ]
+      // });
+
+      // Called by Networked-Aframe when connected to server
+      function onConnect () {
+        console.log("onConnect", new Date());
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
The example is similar to #326 but here with spawned spheres.
I created a `spawner-persistent` component and `persistent-p2p` that handle the logic of keeping the persistent entities peer to peer. The spheres are kept in the room if there is at least one participant remaining in the room.

This is related to #265, it's the first time we use the `applyPersistentFirstSync` api in an example.

Next example would be persisting it server side.