### PR TITLE
Add a spawned persistent spheres (server side) example

### DIFF
--- a/server/easyrtc-server.js
+++ b/server/easyrtc-server.js
@@ -67,6 +67,88 @@ easyrtc.events.on("easyrtcAuth", (socket, easyrtcid, msg, socketCallback, callba
     });
 });
 
+const ROOM_OBJECTS = {
+  _dirty: false
+};
+
+const NAF_MSG_TYPES = ["u", "um", "r"];
+easyrtc.events.on("easyrtcMsg", (connectionObj, msg, socketCallback, next) => {
+    easyrtc.events.defaultListeners.easyrtcMsg(connectionObj, msg, socketCallback, next);
+    const room = msg.targetRoom;
+    const msgType = msg.msgType;
+    // NAF broadcasts to the room (msg.targetRoom defined, msg.targetEasyrtcid undefined)
+    // or send to a participant (msg.targetRoom undefined, msg.targetEasyrtcid defined)
+    // We care only about broadcast msg so when msg.targetRoom is defined.
+    if (room && msgType && NAF_MSG_TYPES.indexOf(msgType) > -1) {
+        let changes = false;
+        // security: verify sender is in the room before keeping the msg.
+        connectionObj.isInRoom(room, (err, isAllowed) => {
+            if (err || !isAllowed) {
+                return;
+            }
+            const appObj = connectionObj.getApp();
+            const appName = appObj.getAppName();
+            let roomObjectsApp = ROOM_OBJECTS[appName];
+            if (!roomObjectsApp) roomObjectsApp = ROOM_OBJECTS[appName] = {};
+            let roomObjects = ROOM_OBJECTS[appName][room];
+            if (!roomObjects) roomObjects = ROOM_OBJECTS[appName][room] = {};
+            if (msgType === "um") {
+                for (let i = 0, len = msg.msgData.d.length; i < len; i++) {
+                    const data = msg.msgData.d[i];
+                    if (!data.persistent) continue;
+                    const existingData = roomObjects[data.networkId];
+                    if (existingData && existingData.lastOwnerTime > data.lastOwnerTime) {
+                        // don't update
+                        continue;
+                    }
+                    roomObjects[data.networkId] = data;
+                    changes = true;
+                    if (data.isFirstSync) {
+                        // TODO: broadcast persistentEntityCreated to all participants
+                    }
+                }
+            } else if (msgType === "u") {
+                const data = msg.msgData;
+                if (!data.persistent) return;
+                const existingData = roomObjects[data.networkId];
+                if (existingData && existingData.lastOwnerTime > data.lastOwnerTime) {
+                    // don't update
+                    return;
+                }
+                roomObjects[data.networkId] = data;
+                changes = true;
+                if (data.isFirstSync) {
+                    // TODO: broadcast persistentEntityCreated to all participants
+                }
+            } else { // msgType == "r"
+                delete roomObjects[msg.msgData.networkId];
+                changes = true;
+            }
+            if (changes) {
+                console.log(room, roomObjects);
+                ROOM_OBJECTS._dirty = true;
+            }
+        });
+    }
+// msg = {
+//  msgType: 'u',
+//  msgData: {
+//    networkId: 'r8b8xyc',
+//    owner: 'cAR6xMK5UatJoooC',
+//    creator: 'cAR6xMK5UatJoooC',
+//    lastOwnerTime: 1647093776600.0208,
+//    template: '#avatar-template',
+//    persistent: false,
+//    parent: null,
+//    components: { '0': [Object], '1': [Object], '2': '#fe20f4' },
+//    isFirstSync: true
+//  },
+//  targetRoom: 'dev'
+// }
+// or
+// msg= { msgType: 'um', msgData: { d: [ [Object] ] }, targetRoom: 'dev' }
+});
+
 // To test, lets print the credential to the console for every room join!
 easyrtc.events.on("roomJoin", (connectionObj, roomName, roomParameter, callback) => {
     console.log("["+connectionObj.getEasyrtcid()+"] Credential retrieved!", connectionObj.getFieldValueSync("credential"));


### PR DESCRIPTION
#327 was using a peer to peer persistence.
In this example, we save the persistent entities server side. This addresses #139

- [x] keep in memory server side the persistent entities (using the NAF `u` persistent firstSync messages may not be the right way though, this requires to have unreliable transport on the websocket, so currently with wseasyrtc, see #324 to use websocket for easyrtc adapter)
- [ ] broadcast persistentEntityCreated message to all participants from the server when a participant create a persistent entity
- [ ] send `persistentEntities` message from the server when a participant join the room
- [ ] `persistent-server` component that do the necessary things with the `persistentEntityCreated` and `persistentEntities` messages coming from the server
- [ ] use NAF option `firstSyncSource` to allow firstSync entities from the server only, see #265
- [ ] persist entities in a file on the filesystem (persisting in postgres via [superbase](https://supabase.com/) out of scope for this repo)
