### PR TITLE
handle update of positional param in networked-audio-source

### DIFF
--- a/src/components/networked-audio-source.js
+++ b/src/components/networked-audio-source.js
@@ -1,5 +1,5 @@
 /* global AFRAME, NAF, THREE */
-var naf = require('../NafIndex');
+const naf = require('../NafIndex');
 
 AFRAME.registerComponent('networked-audio-source', {
   schema: {
@@ -15,17 +15,18 @@ AFRAME.registerComponent('networked-audio-source', {
   },
 
   init: function () {
-    this.listener = null;
     this.stream = null;
+    this.sound = null;
+    this.audioEl = null;
 
-    this._setMediaStream = this._setMediaStream.bind(this);
+    this.setupSound = this.setupSound.bind(this);
 
     NAF.utils.getNetworkedEntity(this.el).then((networkedEl) => {
       const ownerId = networkedEl.components.networked.data.owner;
 
       if (ownerId) {
         NAF.connection.adapter.getMediaStream(ownerId, this.data.streamName)
-          .then(this._setMediaStream)
+          .then(this.setupSound)
           .catch((e) => naf.log.error(`Error getting media stream for ${ownerId}`, e));
       } else {
         // Correctly configured local entity, perhaps do something here for enabling debug audio loopback
@@ -33,55 +34,27 @@ AFRAME.registerComponent('networked-audio-source', {
     });
   },
 
-  update() {
-    this._setPannerProperties();
-  },
-
-  _setMediaStream(newStream) {
-    if(!this.sound) {
-      this.setupSound();
+  update(oldData) {
+    if (!this.sound) {
+      return;
     }
-
-    if(newStream != this.stream) {
-      if(this.stream) {
-        this.sound.disconnect();
-      }
-      if(newStream) {
-        // Chrome seems to require a MediaStream be attached to an AudioElement before AudioNodes work correctly
-        // We don't want to do this in other browsers, particularly in Safari, which actually plays the audio despite
-        // setting the volume to 0.
-        if (/chrome/i.test(navigator.userAgent)) {
-          this.audioEl = new Audio();
-          this.audioEl.setAttribute("autoplay", "autoplay");
-          this.audioEl.setAttribute("playsinline", "playsinline");
-          this.audioEl.srcObject = newStream;
-          this.audioEl.volume = 0; // we don't actually want to hear audio from this element
-        }
-
-        const soundSource = this.sound.context.createMediaStreamSource(newStream); 
-        this.sound.setNodeSource(soundSource);
-        this.el.emit('sound-source-set', { soundSource });
-      }
-      this.stream = newStream;
+    if (oldData.positional !== this.data.positional) {
+      this.destroySound();
+      this.setupSound(this.stream);
+    } else if (this.data.positional) {
+      this._setPannerProperties();
     }
   },
 
   _setPannerProperties() {
-    if (this.sound && this.data.positional) {
-      this.sound.setDistanceModel(this.data.distanceModel);
-      this.sound.setMaxDistance(this.data.maxDistance);
-      this.sound.setRefDistance(this.data.refDistance);
-      this.sound.setRolloffFactor(this.data.rolloffFactor);
-    }
+    this.sound.setDistanceModel(this.data.distanceModel);
+    this.sound.setMaxDistance(this.data.maxDistance);
+    this.sound.setRefDistance(this.data.refDistance);
+    this.sound.setRolloffFactor(this.data.rolloffFactor);
   },
 
-  remove: function() {
-    if (!this.sound) return;
-
-    this.el.removeObject3D(this.attrName);
-    if (this.stream) {
-      this.sound.disconnect();
-    }
+  remove() {
+    this.destroySound();
 
     if (this.audioEl) {
       this.audioEl.pause();
@@ -91,13 +64,20 @@ AFRAME.registerComponent('networked-audio-source', {
     }
   },
 
-  setupSound: function() {
-    var el = this.el;
-    var sceneEl = el.sceneEl;
-
+  destroySound() {
     if (this.sound) {
-      el.removeObject3D(this.attrName);
+      this.sound.disconnect();
+      this.el.removeObject3D(this.attrName);
+      this.sound = null;
     }
+  },
+
+  setupSound(newStream) {
+    if (!newStream) return;
+    const isRemoved = !this.el.parentNode;
+    if (isRemoved) return;
+    const el = this.el;
+    const sceneEl = el.sceneEl;
 
     if (!sceneEl.audioListener) {
       sceneEl.audioListener = new THREE.AudioListener();
@@ -106,12 +86,31 @@ AFRAME.registerComponent('networked-audio-source', {
         evt.detail.cameraEl.getObject3D('camera').add(sceneEl.audioListener);
       });
     }
-    this.listener = sceneEl.audioListener;
 
     this.sound = this.data.positional
-      ? new THREE.PositionalAudio(this.listener)
-      : new THREE.Audio(this.listener);
+      ? new THREE.PositionalAudio(sceneEl.audioListener)
+      : new THREE.Audio(sceneEl.audioListener);
     el.setObject3D(this.attrName, this.sound);
-    this._setPannerProperties();
+    if (this.data.positional) {
+      this._setPannerProperties();
+    }
+
+    // Chrome seems to require a MediaStream be attached to an AudioElement before AudioNodes work correctly
+    // We don't want to do this in other browsers, particularly in Safari, which actually plays the audio despite
+    // setting the volume to 0.
+    if (/chrome/i.test(navigator.userAgent)) {
+      if (!this.audioEl) {
+        this.audioEl = new Audio();
+        this.audioEl.setAttribute("autoplay", "autoplay");
+        this.audioEl.setAttribute("playsinline", "playsinline");
+        this.audioEl.srcObject = newStream;
+        this.audioEl.volume = 0; // we don't actually want to hear audio from this element
+      }
+    }
+
+    const soundSource = this.sound.context.createMediaStreamSource(newStream);
+    this.sound.setNodeSource(soundSource);
+    this.el.emit('sound-source-set', { soundSource });
+    this.stream = newStream;
   }
 });


### PR DESCRIPTION
This closes #245

To test it, open http://localhost:8080/basic-audio.html and connect two users
and move away from the other avatar so you almost don't hear them.

in the console:
```
const players = document.querySelectorAll('.avatar');
// switch to non positional, you should now hear the other avatar
for (let i = 0; i < players.length; i++) { players[i].setAttribute('networked-audio-source', 'positional:false'); }
// switch to positional, the sound of the other avatar should be attenuated
for (let i = 0; i < players.length; i++) { players[i].setAttribute('networked-audio-source', 'positional:true'); }
```