### PR TITLE
compatibility with threejs r141

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -1,7 +1,7 @@
 /* global AFRAME, NAF, THREE */
 var deepEqual = require('../DeepEquals');
 var InterpolationBuffer = require('buffered-interpolation');
-var DEG2RAD = THREE.Math.DEG2RAD;
+var DEG2RAD = THREE.MathUtils.DEG2RAD;
 var OBJECT3D_COMPONENTS = ['position', 'rotation', 'scale'];
 
 function defaultRequiresUpdate() {


### PR DESCRIPTION
Add compatibility with threejs r141 (current aframe master), THREE.Math was removed, you need to use THREE.MathUtils now.
Note that THREE.MathUtils was available since at least threejs r125 aframe 1.2.0.
But a reminder latest networked-aframe is for aframe 1.3.0 and above only because of the buffered-interpolation dependency.