### PR TITLE
Simplify examples

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "trailingComma": "none",
+  "singleQuote": true
+}

--- a/examples/360.html
+++ b/examples/360.html
@@ -1,54 +1,60 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>360 Image Example — Networked-Aframe</title>
-    <meta name="description" content="360 Image Example — Networked-Aframe">
+    <meta name="description" content="360 Image Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: 360;
       debug: true;
-    ">
+      adapter: wseasyrtc;
+    "
+    >
       <a-assets>
+        <!-- Templates -->
+
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -57,36 +63,28 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
       <a-sky src="img/puydesancy.jpg" rotation="0 -130 0"></a-sky>
     </a-scene>
 
     <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
+      // Called by Networked-Aframe when connected to server
+      function onConnect() {
+        console.log('onConnect', new Date());
+      }
     </script>
   </body>
 </html>

--- a/examples/adapter-test/adapter-test-receive.html
+++ b/examples/adapter-test/adapter-test-receive.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Dev Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -10,11 +11,9 @@
     <script src="/dist/networked-aframe.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
 
     <style>
-
       .fail {
         background-color: red;
         color: white;
@@ -26,29 +25,28 @@
         color: white;
         padding: 0 5px;
       }
-
     </style>
 
     <script>
-      NAF.connection.subscribeToDataChannel('reliableBroadcast', function() {
+      NAF.connection.subscribeToDataChannel('reliableBroadcast', function () {
         var label = document.getElementById('reliable-broadcast');
         label.innerHTML = 'success';
         label.className = 'success';
       });
 
-      NAF.connection.subscribeToDataChannel('unreliableBroadcast', function() {
+      NAF.connection.subscribeToDataChannel('unreliableBroadcast', function () {
         var label = document.getElementById('unreliable-broadcast');
         label.innerHTML = 'success';
         label.className = 'success';
       });
 
-      NAF.connection.subscribeToDataChannel('reliableSend', function() {
+      NAF.connection.subscribeToDataChannel('reliableSend', function () {
         var label = document.getElementById('reliable-send');
         label.innerHTML = 'success';
         label.className = 'success';
       });
 
-      NAF.connection.subscribeToDataChannel('unreliableSend', function() {
+      NAF.connection.subscribeToDataChannel('unreliableSend', function () {
         var label = document.getElementById('unreliable-send');
         label.innerHTML = 'success';
         label.className = 'success';
@@ -56,26 +54,32 @@
     </script>
   </head>
   <body>
-
     <div>
       <p>Broadcast reliable test result: <span id="reliable-broadcast" class="fail">waiting</span></p>
-      <p>Broadcast unreliable  test result: <span id="unreliable-broadcast" class="fail">waiting</span></p>
+      <p>Broadcast unreliable test result: <span id="unreliable-broadcast" class="fail">waiting</span></p>
       <p>Send reliable test result: <span id="reliable-send" class="fail">waiting</span></p>
       <p>Send unreliable test result: <span id="unreliable-send" class="fail">waiting</span></p>
     </div>
 
     <!-- Uncomment the block corresponding to the network adapter you want to test -->
 
-    <a-scene embedded networked-scene="
+    <a-scene
+      embedded
+      networked-scene="
       room: dev;
       debug: true;
       adapter: wseasyrtc;
-    ">
+    "
+    >
+    </a-scene>
 
-    <!-- <a-scene embedded networked-scene="
+    <!-- <a-scene
+      embedded
+      networked-scene="
       room: dev;
       debug: true;
       adapter: easyrtc;
-    "> -->
+    "
+    ></a-scene> -->
   </body>
 </html>

--- a/examples/adapter-test/adapter-test-send.html
+++ b/examples/adapter-test/adapter-test-send.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Dev Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -10,7 +11,6 @@
     <script src="/dist/networked-aframe.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
 
     <script>
@@ -25,8 +25,7 @@
         var clients = NAF.connection.getConnectedClients();
 
         var firstClient;
-        for (firstClient in clients)
-          break;
+        for (firstClient in clients) break;
 
         console.error(clients);
         console.error(firstClient);
@@ -37,20 +36,21 @@
     </script>
   </head>
   <body>
-
     <div>
       <p>Sender. Open first receiver to test.</p>
     </div>
 
     <!-- Uncomment the block corresponding to the network adapter you want to test -->
 
-    <a-scene embedded networked-scene="
+    <a-scene
+      embedded
+      networked-scene="
       room: dev;
       debug: true;
       adapter: wseasyrtc;
-    ">
-
-    <!-- <a-scene embedded networked-scene="
+    "
+    >
+      <!-- <a-scene embedded networked-scene="
       room: dev;
       debug: true;
       adapter: easyrtc;

--- a/examples/adapter-test/index.html
+++ b/examples/adapter-test/index.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Iframe Dev Example — Networked-Aframe</title>
-  <meta name="description" content="Iframe Example — Networked-Aframe">
+  <head>
+    <meta charset="utf-8" />
+    <title>Iframe Dev Example — Networked-Aframe</title>
+    <meta name="description" content="Iframe Example — Networked-Aframe" />
 
-  <style>
-    iframe { width: 50%; height: 100%; border-width: 0 10px 10px 0; }
+    <style>
+      iframe {
+        width: 50%;
+        height: 100%;
+        border-width: 0 10px 10px 0;
+      }
 
-    .left { position: absolute; top: 0; left: 0; }
-    .right { position: absolute; top: 0; right: 0; }
-  </style>
-</head>
-<body>
-
-<iframe class="left" src="adapter-test-send.html"></iframe>
-<iframe class="right" src="adapter-test-receive.html"></iframe>
-
-</body>
+      .left {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .right {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe class="left" src="adapter-test-send.html"></iframe>
+    <iframe class="right" src="adapter-test-receive.html"></iframe>
+  </body>
 </html>

--- a/examples/ar-index.html
+++ b/examples/ar-index.html
@@ -1,11 +1,12 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Networked-Aframe AR Examples</title>
-    <meta name="description" content="Collection of AR examples for networked-aframe">
+    <meta name="description" content="Collection of AR examples for networked-aframe" />
     <style>
       html {
         background: #2c70e0;
-        color: #FAFAFA;
+        color: #fafafa;
         font-family: monospace;
         font-size: 20px;
         padding: 10px 20px;
@@ -14,7 +15,7 @@
         font-weight: 300;
       }
       a {
-        color: #FAFAFA;
+        color: #fafafa;
         /*display: block;*/
         padding: 15px 0;
       }
@@ -28,33 +29,79 @@
     <p>To view AR examples follow these steps:</p>
 
     <ol>
-    <li>Grab two devices, one must have a camera</li>
-    <li>Open <a href="https://jeromeetienne.github.io/AR.js/data/images/HIRO.jpg">this marker</a> on one device</li>
-    <li>Open one of the examples below on the device with a camera</li>
-    <li>If other users are in the corresponding VR example, point the camera at the marker and voila</li>
-    <li>If nobody is in the example, grab a third device or open a new tab and have it join the <a href="index.html">corresponding VR example</a></li>
-    <li>Now point the camera at the marker and you should see the avatar near the marker</li>
+      <li>Grab two devices, one must have a camera</li>
+      <li>Open <a href="https://jeromeetienne.github.io/AR.js/data/images/HIRO.jpg">this marker</a> on one device</li>
+      <li>Open one of the examples below on the device with a camera</li>
+      <li>If other users are in the corresponding VR example, point the camera at the marker and voila</li>
+      <li>
+        If nobody is in the example, grab a third device or open a new tab and have it join the
+        <a href="index.html">corresponding VR example</a>
+      </li>
+      <li>Now point the camera at the marker and you should see the avatar near the marker</li>
     </ol>
-
 
     <h3>Examples</h3>
 
     <a href="basic-ar.html">Basic AR</a>
-    <br>
-    <br>
+    <br />
+    <br />
     <a href="shooter-ar.html">Shooter AR</a>
 
-    <br><br>
+    <br /><br />
 
-    <p>Want to help make better examples? That would be awesome! Contact <a href="https://twitter.com/haydenlee37" target="_blank">Hayden on twitter</a>.</p>
+    <p>
+      Want to help make better examples? That would be awesome! Contact
+      <a href="https://twitter.com/haydenlee37" target="_blank">Hayden on twitter</a>.
+    </p>
 
     <!-- GitHub Corner. -->
     <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      <svg
+        width="80"
+        height="80"
+        viewBox="0 0 250 250"
+        style="fill: #222; color: #fff; position: absolute; top: 0; border: 0; right: 0"
+      >
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+        <path
+          d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+          fill="currentColor"
+          style="transform-origin: 130px 106px"
+          class="octo-arm"
+        ></path>
+        <path
+          d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+          fill="currentColor"
+          class="octo-body"
+        ></path>
       </svg>
     </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+    <style>
+      .github-corner:hover .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+      }
+      @keyframes octocat-wave {
+        0%,
+        100% {
+          transform: rotate(0);
+        }
+        20%,
+        60% {
+          transform: rotate(-25deg);
+        }
+        40%,
+        80% {
+          transform: rotate(10deg);
+        }
+      }
+      @media (max-width: 500px) {
+        .github-corner:hover .octo-arm {
+          animation: none;
+        }
+        .github-corner .octo-arm {
+          animation: octocat-wave 560ms ease-in-out;
+        }
+      }
     </style>
   </body>
 </html>

--- a/examples/basic-2.html
+++ b/examples/basic-2.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Iframe Dev Example — Networked-Aframe</title>
-  <meta name="description" content="Iframe Example — Networked-Aframe">
+  <head>
+    <meta charset="utf-8" />
+    <title>Iframe Example — Networked-Aframe</title>
+    <meta name="description" content="Iframe Example — Networked-Aframe" />
 
-  <style>
-    iframe { width: 50%; height: 100%; border-width: 0 10px 10px 0; }
+    <style>
+      iframe {
+        width: 50%;
+        height: 100%;
+        border-width: 0 10px 10px 0;
+      }
 
-    .left { position: absolute; top: 0; left: 0; }
-    .right { position: absolute; top: 0; right: 0; }
-  </style>
-</head>
-<body>
-
-<iframe class="left" src="basic.html"></iframe>
-<iframe class="right" src="basic.html"></iframe>
-
-</body>
+      .left {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .right {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe class="left" src="basic.html"></iframe>
+    <iframe class="right" src="basic.html"></iframe>
+  </body>
 </html>

--- a/examples/basic-4.html
+++ b/examples/basic-4.html
@@ -1,25 +1,43 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Iframe Dev Example — Networked-Aframe</title>
-  <meta name="description" content="Iframe Example — Networked-Aframe">
+  <head>
+    <meta charset="utf-8" />
+    <title>Iframe Example — Networked-Aframe</title>
+    <meta name="description" content="Iframe Example — Networked-Aframe" />
 
-  <style>
-    iframe { width: 50%; height: 50%; border-width: 0 10px 10px 0; }
+    <style>
+      iframe {
+        width: 50%;
+        height: 50%;
+        border-width: 0 10px 10px 0;
+      }
 
-    .tl { position: absolute; top: 0; left: 0; }
-    .tr { position: absolute; top: 0; right: 0; }
-    .bl { position: absolute; left: 0;  bottom: 0; }
-    .br { position: absolute; right: 0; bottom: 0; }
-  </style>
-</head>
-<body>
-
-<iframe class="tl" src="basic.html"></iframe>
-<iframe class="tr" src="basic.html"></iframe>
-<iframe class="bl" src="basic.html"></iframe>
-<iframe class="br" src="basic.html"></iframe>
-
-</body>
+      .tl {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .tr {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+      .bl {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+      }
+      .br {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe class="tl" src="basic.html"></iframe>
+    <iframe class="tr" src="basic.html"></iframe>
+    <iframe class="bl" src="basic.html"></iframe>
+    <iframe class="br" src="basic.html"></iframe>
+  </body>
 </html>

--- a/examples/basic-ar.html
+++ b/examples/basic-ar.html
@@ -1,74 +1,78 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Basic AR Example — Networked-Aframe</title>
-    <meta name="description" content="Basic AR Example — Networked-Aframe">
+    <meta name="description" content="Basic AR Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
 
     <!-- AR -->
     <script src="https://rawgit.com/jeromeetienne/ar.js/master/aframe/build/aframe-ar.js"></script>
-    <script>THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/'</script>
+    <script>
+      THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/';
+    </script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
     <script src="js/spawn-in-circle.component.js"></script>
 
     <script>
-      function onARConnect () {
+      function onARConnect() {
         console.log('AR Client Connected');
       }
     </script>
   </head>
   <body>
-
-    <a-scene artoolkit='sourceType: webcam;' network-scene="
+    <a-scene
+      artoolkit="sourceType: webcam"
+      network-scene="
       room: basic;
       debug: true;
       onConnect: onARConnect;
-    ">
+    "
+    >
       <a-assets>
         <!-- Templates -->
 
         <!-- Avatar -->
-        <script id="avatar-template" type="text/html">
+        <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              color="#5985ff"
-              scale="0.45 0.5 0.4"
-              random-color
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" color="#5985ff" scale="0.45 0.5 0.4" random-color></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
-        </script>
+        </template>
 
         <!-- /Templates -->
       </a-assets>
@@ -76,31 +80,7 @@
       <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
       <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
 
-      <a-marker-camera preset='hiro'></a-marker-camera>
+      <a-marker-camera preset="hiro"></a-marker-camera>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material'
-          }
-        ]
-      });
-    </script>
   </body>
 </html>

--- a/examples/basic-audio.html
+++ b/examples/basic-audio.html
@@ -1,64 +1,63 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Positional Audio Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Positional Audio Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: basic-audio;
       debug: true;
       adapter: easyrtc;
       audio: true;
-    ">
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar" networked-audio-source>
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -67,38 +66,23 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
 
     <div class="actions">
       <button id="mic-btn" type="button" class="button">Mute Mic</button>
@@ -107,38 +91,15 @@
     <script>
       // Mic status
       let micEnabled = true;
-      // Mic button ele
+      // Mic button element
       const micBtnEle = document.getElementById('mic-btn');
-      // On mobile remove elements that are resource heavy
-      const isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        const particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
 
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
 
         // Handle mic button click (Mute and Unmute)
-        micBtnEle.addEventListener('click', function() {
+        micBtnEle.addEventListener('click', function () {
           NAF.connection.adapter.enableMicrophone(!micEnabled);
           micEnabled = !micEnabled;
           micBtnEle.textContent = micEnabled ? 'Mute Mic' : 'Unmute Mic';

--- a/examples/basic-events.html
+++ b/examples/basic-events.html
@@ -1,61 +1,61 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Events Example — Networked-Aframe</title>
+    <meta name="description" content="Events Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: dev;
       debug: true;
-    ">
+      adapter: wseasyrtc;
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -64,66 +64,27 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
+      function onConnect() {
         console.error('On connected to NAF -', new Date());
 
         // Examples of listening to NAF events
@@ -143,7 +104,7 @@
           console.error('entityCreated event', evt.detail.el);
         });
 
-        document.body.addEventListener('entityRemoved', function(evt) {
+        document.body.addEventListener('entityRemoved', function (evt) {
           console.error('entityRemoved event. Entity networkId =', evt.detail.networkId);
         });
       }

--- a/examples/basic-multi-streams.html
+++ b/examples/basic-multi-streams.html
@@ -1,78 +1,88 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Multi Streams Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Multi Streams Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: ['position', 'rotation']
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
   </head>
   <body>
-    <a-scene networked-scene="
-      room: basic-multi-stream;
+    <a-scene
+      networked-scene="
+      room: basic-multi-streams;
       debug: true;
       adapter: easyrtc;
       audio: false;
       video: true;
-    ">
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-plane color="#FFF" width="4" height="3" position="0 .6 0" material="side: back" networked-video-source></a-plane>
-            <a-plane color="#FFF" width="2" height="1" position="0 .7 -0.001" material="side: back" networked-video-source="streamName: screen"></a-plane>
+            <a-plane
+              color="#FFF"
+              width="4"
+              height="3"
+              position="0 .6 0"
+              material="side: back"
+              networked-video-source
+            ></a-plane>
+            <a-plane
+              color="#FFF"
+              width="2"
+              height="1"
+              position="0 .7 -0.001"
+              material="side: back"
+              networked-video-source="streamName: screen"
+            ></a-plane>
           </a-entity>
         </template>
 
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
 
     <div class="actions">
       <button id="camera-btn" type="button" class="button">Hide Camera</button>
@@ -98,35 +108,26 @@
         particles.parentNode.removeChild(particles);
       }
 
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation'
-        ]
-      });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
 
         // Handle camera button click (Off and On)
-        cameraBtnEle.addEventListener('click', function() {
+        cameraBtnEle.addEventListener('click', function () {
           NAF.connection.adapter.enableCamera(!cameraEnabled);
           cameraEnabled = !cameraEnabled;
           cameraBtnEle.textContent = cameraEnabled ? 'Hide Camera' : 'Show Camera';
         });
 
         // Handle screen button click (Off and On)
-        screenBtnEle.addEventListener('click', function() {
+        screenBtnEle.addEventListener('click', function () {
           if (screenEnabled) {
-            NAF.connection.adapter.removeLocalMediaStream("screen");
+            NAF.connection.adapter.removeLocalMediaStream('screen');
             screenEnabled = false;
             screenBtnEle.textContent = 'Share screen';
           } else {
             navigator.mediaDevices.getDisplayMedia().then((stream) => {
-              NAF.connection.adapter.addLocalMediaStream(stream, "screen");
+              NAF.connection.adapter.addLocalMediaStream(stream, 'screen');
               screenEnabled = true;
               screenBtnEle.textContent = 'Stop Screen';
             });

--- a/examples/basic-persistent.html
+++ b/examples/basic-persistent.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Persistent sphere — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Persistent Sphere Example — Networked-Aframe</title>
+    <meta name="description" content="Persistent Sphere Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -12,7 +13,7 @@
       // see issue https://github.com/networked-aframe/networked-aframe/issues/267
       NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
       NAF.schemas.getComponents = (template) => {
-        if (!NAF.schemas.hasTemplate("#avatar-template")) {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
@@ -26,11 +27,11 @@
             ]
           });
         }
-        if (!NAF.schemas.hasTemplate("#sphere-template")) {
+        if (!NAF.schemas.hasTemplate('#sphere-template')) {
           NAF.schemas.add({
             template: '#sphere-template',
             components: [
-              "position",
+              'position',
               {
                 component: 'material',
                 property: 'color'
@@ -40,12 +41,11 @@
         }
         const components = NAF.schemas.getComponentsOriginal(template);
         return components;
-      }
+      };
     </script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <script src="/js/color-changer.component.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
@@ -60,10 +60,6 @@
         adapter: wseasyrtc"
     >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
         <template id="sphere-template">
           <a-entity class="raycastable" geometry="primitive: sphere" material="color: red" color-changer></a-entity>
@@ -72,33 +68,13 @@
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -107,20 +83,24 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity id="sphere" networked="template:#sphere-template;networkId:sphere;persistent:true;owner:scene"></a-entity>
+      <a-entity
+        id="sphere"
+        networked="template:#sphere-template;networkId:sphere;persistent:true;owner:scene"
+      ></a-entity>
       <!--
         Specifying a owner that isn't a real participant is used so that the
         participant joining the room won't send this entity because not the
@@ -129,58 +109,21 @@
         defined by the current owner of the sphere in the room.
       -->
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
     <div class="controls">
-      <p>Click on the sphere to change its color. The color is shared between the participants. The sphere won't be removed if the current owner (the latest participant that clicked on the sphere) leaves the room.</p>
+      <p>
+        Click on the sphere to change its color. The color is shared between the participants. The sphere won't be
+        removed if the current owner (the latest participant that clicked on the sphere) leaves the room.
+      </p>
     </div>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      // NAF.schemas.add({
-      //   template: '#avatar-template',
-      //   components: [
-      //     'position',
-      //     'rotation',
-      //     {
-      //       selector: '.head',
-      //       component: 'material',
-      //       property: 'color'
-      //     }
-      //   ]
-      // });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/basic-video.html
+++ b/examples/basic-video.html
@@ -1,78 +1,88 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Video Streaming Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Video Streaming Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: ['position', 'rotation']
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: basic-video;
       debug: true;
       adapter: easyrtc;
       audio: false;
       video: true;
-    ">
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-             <a-plane  color="#FFF" width="4" height="3" position="0 .6 0"  material="side: front" networked-video-source></a-plane>
-             <a-plane  color="#FFF" width="4" height="3" position="0 .6 0"  material="side: back" networked-video-source></a-plane>
+            <a-plane
+              color="#FFF"
+              width="4"
+              height="3"
+              position="0 .6 0"
+              material="side: front"
+              networked-video-source
+            ></a-plane>
+            <a-plane
+              color="#FFF"
+              width="4"
+              height="3"
+              position="0 .6 0"
+              material="side: back"
+              networked-video-source
+            ></a-plane>
           </a-entity>
         </template>
 
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
 
     <div class="actions">
       <button id="camera-btn" type="button" class="button">Hide Camera</button>
@@ -84,29 +94,12 @@
       // Camera button element
       const cameraBtnEle = document.getElementById('camera-btn');
 
-      // On mobile remove elements that are resource heavy
-      const isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        const particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation'
-        ]
-      });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
 
         // Handle camera button click (Off and On)
-        cameraBtnEle.addEventListener('click', function() {
+        cameraBtnEle.addEventListener('click', function () {
           NAF.connection.adapter.enableCamera(!cameraEnabled);
           cameraEnabled = !cameraEnabled;
           cameraBtnEle.textContent = cameraEnabled ? 'Hide Camera' : 'Show Camera';

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Basic Example — Networked-Aframe</title>
+    <meta name="description" content="Basic Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -12,7 +13,7 @@
       // see issue https://github.com/networked-aframe/networked-aframe/issues/267
       NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
       NAF.schemas.getComponents = (template) => {
-        if (!NAF.schemas.hasTemplate("#avatar-template")) {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
@@ -28,57 +29,33 @@
         }
         const components = NAF.schemas.getComponentsOriginal(template);
         return components;
-      }
+      };
     </script>
-
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
-      room: dev;
+    <a-scene
+      networked-scene="
+      room: basic;
       debug: true;
       adapter: wseasyrtc;
-    ">
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -87,48 +64,23 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
-    <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
 
     <script>
       // Define custom schema for syncing avatar color, set by random-color
@@ -146,8 +98,8 @@
       // });
 
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/child-entities.html
+++ b/examples/child-entities.html
@@ -1,66 +1,74 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Dev Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+
+          if (!NAF.schemas.hasTemplate('#face-template')) {
+            NAF.schemas.add({
+              template: '#face-template',
+              components: ['position', 'rotation']
+            });
+          }
+        }
+
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: dev;
       debug: true;
-      adapter: easyrtc;
-    ">
+      adapter: wseasyrtc;
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
           </a-entity>
         </template>
 
         <template id="face-template">
-          <a-entity class="face"
-              position="0 0.05 0"
-            >
-            <a-sphere class="eye"
-              color="#efefef"
-              position="0.16 0.1 -0.35"
-              scale="0.12 0.12 0.12"
-            >
-              <a-sphere class="pupil"
-                color="#000"
-                position="0 0 -1"
-                scale="0.2 0.2 0.2"
-              ></a-sphere>
+          <a-entity class="face" position="0 0.05 0">
+            <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+              <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
             </a-sphere>
-            <a-sphere class="eye"
-              color="#efefef"
-              position="-0.16 0.1 -0.35"
-              scale="0.12 0.12 0.12"
-            >
-              <a-sphere class="pupil"
-                color="#000"
-                position="0 0 -1"
-                scale="0.2 0.2 0.2"
-              ></a-sphere>
+            <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+              <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
             </a-sphere>
           </a-entity>
         </template>
@@ -68,76 +76,29 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
-        <a-entity id="face" networked="template:#face-template;attachTemplateToLocal:false;"></a-entity>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+          <a-entity id="face" networked="template:#face-template;attachTemplateToLocal:false;"></a-entity>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
-
-      NAF.schemas.add({
-        template: '#face-template',
-        components: [
-          'position',
-          'rotation'
-        ]
-      });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/disconnect.html
+++ b/examples/disconnect.html
@@ -1,58 +1,55 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta name="description" content="Dev Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
     <a-scene>
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -61,53 +58,30 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-
       var roomIndex = 0;
-      document.body.onkeyup = function(e){
-        if(e.keyCode == 32){
+      document.body.onkeyup = function (e) {
+        if (e.keyCode == 32) {
           var scene = document.querySelector('a-scene');
-          if(scene.hasAttribute('networked-scene')) {
+          if (scene.hasAttribute('networked-scene')) {
             scene.removeAttribute('networked-scene');
           } else {
             scene.setAttribute('networked-scene', 'debug:true;room:disconnect-' + roomIndex + ';adapter:wseasyrtc');
@@ -115,27 +89,11 @@
             roomIndex++;
           }
         }
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
+      };
 
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/google-blocks.html
+++ b/examples/google-blocks.html
@@ -1,37 +1,52 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Basic Example — Networked-Aframe</title>
-    <meta name="description" content="Basic Example — Networked-Aframe">
+    <meta name="description" content="Basic Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: ['position', 'rotation']
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-
     <a-scene
       renderer="colorManagement: true"
       networked-scene="
       room: blocks;
       debug: true;
-    ">
+      adapter: wseasyrtc;
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <a-asset-item id="raccoon-obj" src="./assets/Raccoon_Blocks/model.obj"></a-asset-item>
         <a-asset-item id="raccoon-mtl" src="./assets/Raccoon_Blocks/materials.mtl"></a-asset-item>
 
         <a-asset-item id="scene-obj" src="./assets/Campfire_Blocks/model.obj"></a-asset-item>
         <a-asset-item id="scene-mtl" src="./assets/Campfire_Blocks/materials.mtl"></a-asset-item>
 
-        <img id="sechelt" crossorigin="anonymous" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/sechelt.jpg">
+        <img
+          id="sechelt"
+          crossorigin="anonymous"
+          src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/sechelt.jpg"
+        />
 
         <!-- Templates -->
 
@@ -43,34 +58,21 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" class="heads" networked="template:#avatar-template;attachTemplateToLocal:false;" camera position="0 1.6 0" spawn-in-circle="radius:2;" wasd-controls look-controls></a-entity>
-
-      <!-- <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity> -->
-      <!-- <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity> -->
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:2"
+          wasd-controls
+          look-controls
+        ></a-entity>
+      </a-entity>
 
       <a-sky id="image-360" radius="100" src="#sechelt" data-set-image-fade-setup="true" animation__fade=""></a-sky>
 
       <a-entity obj-model="obj: #scene-obj; mtl: #scene-mtl" position="-0.542 1.5 -6.206" scale="30 30 30"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
-    <script>
-      // Define custom schema for syncing avatar
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation'
-        ]
-      });
-    </script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,11 +1,11 @@
 <html>
   <head>
     <title>Networked-Aframe Examples</title>
-    <meta name="description" content="Collection of examples for networked-aframe">
+    <meta name="description" content="Collection of examples for networked-aframe" />
     <style>
       html {
-        background: #33425B;
-        color: #FAFAFA;
+        background: #33425b;
+        color: #fafafa;
         font-family: monospace;
         font-size: 20px;
         padding: 10px 20px;
@@ -14,7 +14,7 @@
         font-weight: 300;
       }
       a {
-        color: #FAFAFA;
+        color: #fafafa;
         /*display: block;*/
         padding: 15px 0;
       }
@@ -76,16 +76,16 @@
     <div>
       <a href="basic-persistent.html">Persistent sphere</a>
       <span>
-        Simple sphere that changes color on click. The color is synced between participants.
-        This is an example of a persistent entity defined in the html.
+        Simple sphere that changes color on click. The color is synced between participants. This is an example of a
+        persistent entity defined in the html.
       </span>
     </div>
     <div>
       <a href="persistent-peer-to-peer.html">Spawned persistent spheres</a>
       <span>
-        Similar to the above example but with spawned spheres.
-        The spheres are kept in the room if there is at least one participant remaining in the room.
-        The persistence is done peer to peer. All spheres are lost if all participants leave the room.
+        Similar to the above example but with spawned spheres. The spheres are kept in the room if there is at least one
+        participant remaining in the room. The persistence is done peer to peer. All spheres are lost if all
+        participants leave the room.
       </span>
     </div>
     <div>
@@ -95,17 +95,65 @@
     <!-- <a href="ar-index.html">AR Examples</a>
     <p>View the above examples as AR scenes using a marker and AR.js</p> -->
 
-    <br>
+    <br />
 
-    <p>Want to help make better examples? That would be awesome! <a href="https://github.com/networked-aframe/networked-aframe/blob/master/CONTRIBUTING.md#join-the-community-on-slack" target="_blank">Contact us on Slack</a>.</p>
+    <p>
+      Want to help make better examples? That would be awesome!
+      <a
+        href="https://github.com/networked-aframe/networked-aframe/blob/master/CONTRIBUTING.md#join-the-community-on-slack"
+        target="_blank"
+        >Contact us on Slack</a
+      >.
+    </p>
 
     <!-- GitHub Corner. -->
     <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      <svg
+        width="80"
+        height="80"
+        viewBox="0 0 250 250"
+        style="fill: #222; color: #fff; position: absolute; top: 0; border: 0; right: 0"
+      >
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+        <path
+          d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+          fill="currentColor"
+          style="transform-origin: 130px 106px"
+          class="octo-arm"
+        ></path>
+        <path
+          d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+          fill="currentColor"
+          class="octo-body"
+        ></path>
       </svg>
     </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+    <style>
+      .github-corner:hover .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+      }
+      @keyframes octocat-wave {
+        0%,
+        100% {
+          transform: rotate(0);
+        }
+        20%,
+        60% {
+          transform: rotate(-25deg);
+        }
+        40%,
+        80% {
+          transform: rotate(10deg);
+        }
+      }
+      @media (max-width: 500px) {
+        .github-corner:hover .octo-arm {
+          animation: none;
+        }
+        .github-corner .octo-arm {
+          animation: octocat-wave 560ms ease-in-out;
+        }
+      }
     </style>
   </body>
 </html>

--- a/examples/ownership-transfer.html
+++ b/examples/ownership-transfer.html
@@ -1,16 +1,61 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Ownership Transfer Example — Networked-Aframe</title>
+    <meta name="description" content="Ownership Transfer Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+
+          if (!NAF.schemas.hasTemplate('#cube-template')) {
+            NAF.schemas.add({
+              template: '#cube-template',
+              components: [
+                'position',
+                {
+                  selector: '.cube',
+                  component: 'rotation'
+                },
+                {
+                  selector: '.cube',
+                  component: 'material',
+                  property: 'color'
+                },
+                {
+                  selector: '.cube',
+                  component: 'toggle-ownership',
+                  property: 'direction'
+                }
+              ]
+            });
+          }
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <script src="/js/spawner.component.js"></script>
     <script src="/js/toggle-ownership.component.js"></script>
@@ -22,49 +67,27 @@
         room: dev;
         debug: true;
         adapter: wseasyrtc;
-      ">
+      "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
         </template>
 
+        <!-- Cube -->
         <template id="cube-template">
           <a-entity>
             <a-box class="cube" toggle-ownership color="#F00"></a-box>
@@ -74,93 +97,33 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        spawner="template:#cube-template"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          spawner="template:#cube-template"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
     <div class="controls">
       <p>Press space to spawn a cube. Press enter to take ownership of all cubes.</p>
     </div>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
-
-      NAF.schemas.add({
-        template: '#cube-template',
-        components: [
-          "position",
-          {
-            selector: '.cube',
-            component: 'rotation'
-          },
-          {
-            selector: '.cube',
-            component: 'material',
-            property: 'color'
-          },
-          {
-            selector: '.cube',
-            component: 'toggle-ownership',
-            property: 'direction'
-          }
-        ]
-      });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/persistent-peer-to-peer.html
+++ b/examples/persistent-peer-to-peer.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Spawned persistent spheres — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Spawned Persistent Spheres Example — Networked-Aframe</title>
+    <meta name="description" content="Spawned Persistent Spheres Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -12,7 +13,7 @@
       // see issue https://github.com/networked-aframe/networked-aframe/issues/267
       NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
       NAF.schemas.getComponents = (template) => {
-        if (!NAF.schemas.hasTemplate("#avatar-template")) {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
@@ -26,11 +27,11 @@
             ]
           });
         }
-        if (!NAF.schemas.hasTemplate("#sphere-template")) {
+        if (!NAF.schemas.hasTemplate('#sphere-template')) {
           NAF.schemas.add({
             template: '#sphere-template',
             components: [
-              "position",
+              'position',
               {
                 component: 'material',
                 property: 'color'
@@ -40,12 +41,11 @@
         }
         const components = NAF.schemas.getComponentsOriginal(template);
         return components;
-      }
+      };
     </script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <script src="/js/color-changer.component.js"></script>
     <script src="/js/spawner-persistent.component.js"></script>
@@ -70,10 +70,6 @@
         adapter: wseasyrtc"
     >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
         <template id="sphere-template">
           <a-entity class="raycastable" geometry="primitive: sphere" material="color: red" color-changer></a-entity>
@@ -82,33 +78,13 @@
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -117,72 +93,36 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        spawner-persistent="template:#sphere-template"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          spawner-persistent="template:#sphere-template"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
     <div class="controls">
-      <p>Press space to spawn a sphere that will persist even if you leave the room at the condition there is a participant that stay in the room.</p>
+      <p>
+        Press space to spawn a sphere that will persist even if you leave the room at the condition there is a
+        participant that stay in the room.
+      </p>
     </div>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      // NAF.schemas.add({
-      //   template: '#avatar-template',
-      //   components: [
-      //     'position',
-      //     'rotation',
-      //     {
-      //       selector: '.head',
-      //       component: 'material',
-      //       property: 'color'
-      //     }
-      //   ]
-      // });
-
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/shooter-2.html
+++ b/examples/shooter-2.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Iframe Dev Example — Networked-Aframe</title>
-  <meta name="description" content="Iframe Example — Networked-Aframe">
+  <head>
+    <meta charset="utf-8" />
+    <title>Shooter 2 players Example — Networked-Aframe</title>
+    <meta name="description" content="Shooter 2 players Example — Networked-Aframe" />
 
-  <style>
-    iframe { width: 50%; height: 100%; border-width: 0 10px 10px 0; }
+    <style>
+      iframe {
+        width: 50%;
+        height: 100%;
+        border-width: 0 10px 10px 0;
+      }
 
-    .left { position: absolute; top: 0; left: 0; }
-    .right { position: absolute; top: 0; right: 0; }
-  </style>
-</head>
-<body>
-
-<iframe class="left" src="shooter.html"></iframe>
-<iframe class="right" src="shooter.html"></iframe>
-
-</body>
+      .left {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .right {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe class="left" src="shooter.html"></iframe>
+    <iframe class="right" src="shooter.html"></iframe>
+  </body>
 </html>

--- a/examples/shooter-ar.html
+++ b/examples/shooter-ar.html
@@ -1,8 +1,8 @@
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Shooter AR Example — Networked-Aframe</title>
-    <meta name="description" content="Shooter AR Example — Networked-Aframe">
+    <meta name="description" content="Shooter AR Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -11,80 +11,55 @@
 
     <!-- AR -->
     <script src="https://rawgit.com/jeromeetienne/ar.js/master/aframe/build/aframe-ar.js"></script>
-    <script>THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/'</script>
+    <script>
+      THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/';
+    </script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
     <script src="js/spawn-in-circle.component.js"></script>
 
     <script>
-      function onARConnect () {
+      function onARConnect() {
         console.log('AR Client Connected');
       }
     </script>
   </head>
   <body>
-
-    <a-scene artoolkit='sourceType: webcam;' network-scene="
+    <a-scene
+      artoolkit="sourceType: webcam;"
+      network-scene="
       room: shooter;
       debug: true;
+      adapter: wseasyrtc;
       onConnect: onARConnect;
-    ">
+    "
+    >
       <a-assets>
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
             <a-entity class="gun">
-              <a-box
-                position="0.51 -0.13 -0.29"
-                scale="0.19 0.23 0.67"
-                color="#000"
-              ></a-box>
-              <a-entity class="gun-tip"
-                position="0.51 -0.10 -0.64"
-              ></a-entity>
+              <a-box position="0.51 -0.13 -0.29" scale="0.19 0.23 0.67" color="#000"></a-box>
+              <a-entity class="gun-tip" position="0.51 -0.10 -0.64"></a-entity>
             </a-entity>
           </a-entity>
         </template>
 
         <!-- Bullet -->
         <template id="bullet-template">
-          <a-sphere class="bullet"
-            scale="0.1 0.1 0.1"
-            color="#fff"
-          ></a-sphere>
+          <a-sphere class="bullet" scale="0.1 0.1 0.1" color="#fff"></a-sphere>
         </template>
 
         <!-- /Templates -->
@@ -93,16 +68,57 @@
       <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
       <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
 
-      <a-marker-camera preset='hiro'></a-marker-camera>
+      <a-marker-camera preset="hiro"></a-marker-camera>
     </a-scene>
 
     <!-- GitHub Corner. -->
     <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      <svg
+        width="80"
+        height="80"
+        viewBox="0 0 250 250"
+        style="fill: #222; color: #fff; position: absolute; top: 0; border: 0; right: 0"
+      >
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+        <path
+          d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+          fill="currentColor"
+          style="transform-origin: 130px 106px"
+          class="octo-arm"
+        ></path>
+        <path
+          d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+          fill="currentColor"
+          class="octo-body"
+        ></path>
       </svg>
     </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+    <style>
+      .github-corner:hover .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+      }
+      @keyframes octocat-wave {
+        0%,
+        100% {
+          transform: rotate(0);
+        }
+        20%,
+        60% {
+          transform: rotate(-25deg);
+        }
+        40%,
+        80% {
+          transform: rotate(10deg);
+        }
+      }
+      @media (max-width: 500px) {
+        .github-corner:hover .octo-arm {
+          animation: none;
+        }
+        .github-corner .octo-arm {
+          animation: octocat-wave 560ms ease-in-out;
+        }
+      }
     </style>
 
     <script>

--- a/examples/shooter.html
+++ b/examples/shooter.html
@@ -1,75 +1,69 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Shooter Example — Networked-Aframe</title>
-    <meta name="description" content="Shooter Example — Networked-Aframe">
+    <meta name="description" content="Shooter Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
-    <script src="js/spawn-in-circle.component.js"></script>
-    <script src="js/gun.component.js"></script>
-    <script src="js/forward.component.js"></script>
-    <script src="js/remove-in-seconds.component.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
+    <script src="/js/spawn-in-circle.component.js"></script>
+    <script src="/js/gun.component.js"></script>
+    <script src="/js/forward.component.js"></script>
+    <script src="/js/remove-in-seconds.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
+    <a-scene
+      networked-scene="
       room: shooter;
       debug: true;
-    ">
+      adapter: wseasyrtc;
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
             <a-entity class="gun">
-              <a-box
-                position="0.51 -0.13 -0.29"
-                scale="0.19 0.23 0.67"
-                color="#000"
-              ></a-box>
-              <a-entity class="gun-tip"
-                position="0.51 -0.10 -0.64"
-              ></a-entity>
+              <a-box position="0.51 -0.13 -0.29" scale="0.19 0.23 0.67" color="#000"></a-box>
+              <a-entity class="gun-tip" position="0.51 -0.10 -0.64"></a-entity>
             </a-entity>
           </a-entity>
         </template>
@@ -77,74 +71,37 @@
         <!-- Bullet -->
         <template id="bullet-template">
           <a-entity>
-            <a-sphere class="bullet"
-              scale="0.1 0.1 0.1"
-              color="#fff"
-            ></a-sphere>
+            <a-sphere class="bullet" scale="0.1 0.1 0.1" color="#fff"></a-sphere>
           </a-entity>
         </template>
 
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
-        gun="bulletTemplate:#bullet-template"
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
+          gun="bulletTemplate:#bullet-template"
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
 
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
     <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
+      // Called by Networked-Aframe when connected to server
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
-    </script>
-
-    <script>
-      // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
     </script>
   </body>
 </html>

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -1,8 +1,8 @@
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Tracked Controllers — Networked-Aframe</title>
-    <meta name="description" content="Tracked Controllers — Networked-Aframe">
+    <meta name="description" content="Tracked Controllers — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
@@ -10,58 +10,58 @@
     <script src="/dist/networked-aframe.js"></script>
 
     <script>
-        // Note the way we're establishing the NAF schema here; this is a bit awkward
-        // because of a recent bug found in the original handling. This mitigates that bug for now,
-        // until a refactor in the future that should fix the issue more cleanly.
-        NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      // Note the way we're establishing the NAF schema here; this is a bit awkward
+      // because of a recent bug found in the original handling. This mitigates that bug for now,
+      // until a refactor in the future that should fix the issue more cleanly.
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
 
-        // This one is necessary, because tracking the .head child component's material's color
-        // won't happen unless we tell NAF to keep it in sync, like here.
-        NAF.schemas.getComponents = (template) => {
-          if (!NAF.schemas.hasTemplate("#head-template")) {
-            NAF.schemas.add({
-              template: '#head-template',
-              components: [
-                // position and rotation are synced by default, but if we declare
-                // a custom schema, then ommitting them will cause them to go untracked.
-                'position',
-                'rotation',
+      // This one is necessary, because tracking the .head child component's material's color
+      // won't happen unless we tell NAF to keep it in sync, like here.
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#head-template')) {
+          NAF.schemas.add({
+            template: '#head-template',
+            components: [
+              // position and rotation are synced by default, but if we declare
+              // a custom schema, then ommitting them will cause them to go untracked.
+              'position',
+              'rotation',
 
-                // In our current example, we don't sync the material.color itself;
-                // we instead sync player-info, which includes color setting + updating.
-                // {
-                //   selector: '.head',
-                //   component: 'material',
-                //   property: 'color'
-                // },
+              // In our current example, we don't sync the material.color itself;
+              // we instead sync player-info, which includes color setting + updating.
+              // {
+              //   selector: '.head',
+              //   component: 'material',
+              //   property: 'color'
+              // },
 
-                // NOTICE THAT WE SYNC PLAYER INFO! this is where color and username are stored
-                'player-info'
-              ]
-            });
-          }
-
-          // We could theoretically add this one in as well, but
-          // since position and rotation are the default tracked components for
-          // networked entities, no schema declaration is necessary. If we did
-          // include it, though, it would look like this:
-
-          // if (!NAF.schemas.hasTemplate("#camera-rig-template")) {
-          //   NAF.schemas.add({
-          //     template: '#camera-rig-template',
-          //      components: [
-          //       'position',
-          //       'rotation',
-          //     ]
-          //   });
-          // }
-
-          // likewise for the left-hand-template and right-hand-template--since we're only
-          // syncing position/rotation, no schema declaration needed!
-
-          const components = NAF.schemas.getComponentsOriginal(template);
-          return components;
+              // NOTICE THAT WE SYNC PLAYER INFO! this is where color and username are stored
+              'player-info'
+            ]
+          });
         }
+
+        // We could theoretically add this one in as well, but
+        // since position and rotation are the default tracked components for
+        // networked entities, no schema declaration is necessary. If we did
+        // include it, though, it would look like this:
+
+        // if (!NAF.schemas.hasTemplate("#camera-rig-template")) {
+        //   NAF.schemas.add({
+        //     template: '#camera-rig-template',
+        //      components: [
+        //       'position',
+        //       'rotation',
+        //     ]
+        //   });
+        // }
+
+        // likewise for the left-hand-template and right-hand-template--since we're only
+        // syncing position/rotation, no schema declaration needed!
+
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
     </script>
 
     <script src="https://cdn.jsdelivr.net/gh/donmccurdy/aframe-extras@v6.1.1/dist/aframe-extras.min.js"></script>
@@ -77,16 +77,16 @@
           // add these with JS:
           // <a-entity hand-controls="hand:left" networked="template:#left-hand-template;attachTemplateToLocal:true;"></a-entity>
           // <a-entity hand-controls="hand:right" networked="template:#right-hand-template;attachTemplateToLocal:true;"></a-entity>
-          ['left', 'right'].forEach(side => {
-            const el = document.createElement('a-entity')
-            el.setAttribute('hand-controls', {hand: side});
-            el.setAttribute('networked', {template: `#${side}-hand-template`, attachTemplateToLocal: false});
+          ['left', 'right'].forEach((side) => {
+            const el = document.createElement('a-entity');
+            el.setAttribute('hand-controls', { hand: side });
+            el.setAttribute('networked', { template: `#${side}-hand-template`, attachTemplateToLocal: false });
             el.setAttribute('id', `my-tracked-${side}-hand`);
             // note that the ID will be applied to THIS client's hands,
             // but not other connected clients,
             // and not on the machine of other connected clients
             this.el.appendChild(el);
-          })
+          });
         },
         init() {
           this.el.sceneEl.addEventListener('enter-vr', this.onEnterVR.bind(this));
@@ -98,29 +98,35 @@
           // https://github.com/n5ro/aframe-extras/tree/master/src/loaders
           // could add as 'networked-hands' component within repo
         }
-      })
+      });
 
       AFRAME.registerComponent('player-info', {
         schema: {
-          name: { type: 'string', default: "user-" + Math.round(Math.random()*10000) },
-          color: { type: 'string', default: '#' + new THREE.Color( Math.random(), Math.random(), Math.random() ).getHexString() },
+          name: { type: 'string', default: 'user-' + Math.round(Math.random() * 10000) },
+          color: {
+            type: 'string',
+            default: '#' + new THREE.Color(Math.random(), Math.random(), Math.random()).getHexString()
+          }
         },
 
-        init: function() {
+        init: function () {
           this.head = this.el.querySelector('.head');
           this.nametag = this.el.querySelector('.nametag');
-          this.ownedByLocalUser = this.el.id === "local-avatar";
+          this.ownedByLocalUser = this.el.id === 'player';
           if (this.ownedByLocalUser) {
-            this.nametagInput = document.getElementById("username-overlay");
+            this.nametagInput = document.getElementById('username-overlay');
             this.nametagInput.value = this.data.name;
           }
         },
 
-        listUsers: function() {
-          console.log("userlist", [...document.querySelectorAll('[player-info]')].map(el => el.components['player-info'].data.name));
+        listUsers: function () {
+          console.log(
+            'userlist',
+            [...document.querySelectorAll('[player-info]')].map((el) => el.components['player-info'].data.name)
+          );
         },
 
-        update: function() {
+        update: function () {
           if (this.head) this.head.setAttribute('material', 'color', this.data.color);
           if (this.nametag) this.nametag.setAttribute('value', this.data.name);
         }
@@ -131,19 +137,20 @@
   <body>
     <input
       id="username-overlay"
-      style="z-index: 100; bottom: 24px; left: 24px; position:fixed;"
-      oninput="document.getElementById('local-avatar').setAttribute('player-info', 'name', this.value)"
+      style="z-index: 100; bottom: 24px; left: 24px; position: fixed"
+      oninput="document.getElementById('player').setAttribute('player-info', 'name', this.value)"
     />
     <a-scene
-      stats
       networked-scene="
         room: handcontrollers;
         debug: true;
-    ">
+        adapter: wseasyrtc;
+    "
+    >
       <a-assets>
         <!-- models are from a-frame repo; see bottom of page for downloads:  https://aframe.io/docs/1.2.0/components/hand-controls.html -->
-         <a-asset-item id="left-hand-model" src="./assets/leftHandHigh.glb"></a-asset-item>
-         <a-asset-item id="right-hand-model" src="./assets/rightHandHigh.glb"></a-asset-item>
+        <a-asset-item id="left-hand-model" src="./assets/leftHandHigh.glb"></a-asset-item>
+        <a-asset-item id="right-hand-model" src="./assets/rightHandHigh.glb"></a-asset-item>
 
         <!--
           NAF Templates
@@ -157,16 +164,23 @@
         <!--      a few spheres make a head + eyes + pupils    -->
         <template id="head-template">
           <a-entity class="avatar" player-info>
-            <a-sphere class="head" scale="0.2 0.22 0.2" ></a-sphere>
-            <a-entity class="face" position="0 0.05 0" >
-              <a-sphere class="eye" color="white" position="0.06 0.05 -0.16" scale="0.04 0.04 0.04" >
+            <a-sphere class="head" scale="0.2 0.22 0.2"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="white" position="0.06 0.05 -0.16" scale="0.04 0.04 0.04">
                 <a-sphere class="pupil" color="black" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
               <a-sphere class="eye" color="white" position="-0.06 0.05 -0.16" scale="0.04 0.04 0.04">
                 <a-sphere class="pupil" color="black" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
-            <a-text class="nametag" value="?" rotation="0 180 0" position=".25 -.35 0" side="double" scale=".5 .5 .5"></a-text>
+            <a-text
+              class="nametag"
+              value="?"
+              rotation="0 180 0"
+              position=".25 -.35 0"
+              side="double"
+              scale=".5 .5 .5"
+            ></a-text>
           </a-entity>
         </template>
 
@@ -187,26 +201,33 @@
         -->
       </a-assets>
 
-      <a-entity environment="preset:starry; groundColor: #000000;"></a-entity>
-      <a-entity light="type:ambient; intensity:.5"></a-entity>
+      <a-entity environment="preset:starry;groundColor:#000000;"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
 
       <!--   Here we declare only the local user's avatar, which we then broadcast to other users     -->
-      <!--   The 'spawn-in-circle' component will set the position and rotation of #camera-rig;
+      <!--   The 'spawn-in-circle' component will set the position and rotation of #cameraRig;
              because this entity also has the networked component, and position and rotation are tracked by default,
              the changes made by spawn-in-circle will be kept in sync with other networked users.
              Also note that by adding the networked component with a template reference, we generate that full template,
              including all applicable child elements. However, because we don't need to see our own avatar, we use the
              `attachTemplateToLocal:false` option. This makes our local copies invisible on our machine, but visible on everyone else's.
       -->
-      <a-entity id="camera-rig"
-                tracked-vr-hands
-                movement-controls="fly:true;"
-                spawn-in-circle="radius:3"
-                networked="template:#camera-rig-template;"
+      <a-entity
+        id="cameraRig"
+        tracked-vr-hands
+        movement-controls="fly:true;"
+        spawn-in-circle="radius:3"
+        networked="template:#camera-rig-template;"
       >
-        <a-entity id="local-avatar" camera position="0 1.6 0" look-controls
-                  networked="template:#head-template;" visible="false">
-        <!-- Here we add the camera. Adding the camera within a 'rig' is standard practice.
+        <a-entity
+          id="player"
+          camera
+          position="0 1.6 0"
+          look-controls
+          networked="template:#head-template;"
+          visible="false"
+        >
+          <!-- Here we add the camera. Adding the camera within a 'rig' is standard practice.
              We set the camera to head height for e.g. computer users, but otherwise never touch it again; if the user enters VR,
              its rotation and position will be updated by the headset in VR. If we need to touch the user's position
              or rotation, we always do that by adjusting the rig parent of the active camera. By making that rig--and the
@@ -225,15 +246,6 @@
         -->
       </a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
 
     <script>
       // old style sync schema declaration, can cause race condition glitch--use new style, shown at top of file
@@ -261,8 +273,8 @@
       // });
 
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>

--- a/examples/webrtc.html
+++ b/examples/webrtc.html
@@ -1,62 +1,61 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>Dev Example — Networked-Aframe</title>
-    <meta name="description" content="Dev Example — Networked-Aframe">
+    <meta charset="utf-8" />
+    <title>Basic Example — Networked-Aframe</title>
+    <meta name="description" content="Basic Example — Networked-Aframe" />
 
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
-
+    <script>
+      // see issue https://github.com/networked-aframe/networked-aframe/issues/267
+      NAF.schemas.getComponentsOriginal = NAF.schemas.getComponents;
+      NAF.schemas.getComponents = (template) => {
+        if (!NAF.schemas.hasTemplate('#avatar-template')) {
+          NAF.schemas.add({
+            template: '#avatar-template',
+            components: [
+              'position',
+              'rotation',
+              {
+                selector: '.head',
+                component: 'material',
+                property: 'color'
+              }
+            ]
+          });
+        }
+        const components = NAF.schemas.getComponentsOriginal(template);
+        return components;
+      };
+    </script>
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
-    <!--<script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/gh/IdeaSpaceVR/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene networked-scene="
-      room: dev;
+    <a-scene
+      networked-scene="
+      room: basic;
       debug: true;
       adapter: easyrtc;
-    ">
+    "
+    >
       <a-assets>
-
-        <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
-
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
           <a-entity class="avatar">
-            <a-sphere class="head"
-              scale="0.45 0.5 0.4"
-            ></a-sphere>
-            <a-entity class="face"
-              position="0 0.05 0"
-            >
-              <a-sphere class="eye"
-                color="#efefef"
-                position="0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+            <a-sphere class="head" scale="0.45 0.5 0.4"></a-sphere>
+            <a-entity class="face" position="0 0.05 0">
+              <a-sphere class="eye" color="#efefef" position="0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
-              <a-sphere class="eye"
-                color="#efefef"
-                position="-0.16 0.1 -0.35"
-                scale="0.12 0.12 0.12"
-              >
-                <a-sphere class="pupil"
-                  color="#000"
-                  position="0 0 -1"
-                  scale="0.2 0.2 0.2"
-                ></a-sphere>
+              <a-sphere class="eye" color="#efefef" position="-0.16 0.1 -0.35" scale="0.12 0.12 0.12">
+                <a-sphere class="pupil" color="#000" position="0 0 -1" scale="0.2 0.2 0.2"></a-sphere>
               </a-sphere>
             </a-entity>
           </a-entity>
@@ -65,67 +64,42 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        camera
-        position="0 1.6 0"
-        spawn-in-circle="radius:3"
-        wasd-controls look-controls
+      <a-entity id="cameraRig">
+        <a-entity
+          id="player"
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera
+          position="0 1.6 0"
+          spawn-in-circle="radius:3"
+          wasd-controls
+          look-controls
         >
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
+          <a-sphere class="head" visible="false" random-color></a-sphere>
+        </a-entity>
       </a-entity>
 
-      <a-entity position="0 0 0"
-        geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"
-        material="src: #grid; repeat: 10000 10000; transparent: true; metalness:0.6; roughness: 0.4; sphericalEnvMap: #sky;"></a-entity>
-
-      <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity>
-      <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity>
-
-      <a-sky src="#sky" rotation="0 -90 0"></a-sky>
-      <a-entity id="particles" particle-system="preset: snow"></a-entity>
+      <a-entity environment="preset:arches"></a-entity>
+      <a-entity light="type:ambient;intensity:0.5"></a-entity>
     </a-scene>
-
-    <!-- GitHub Corner. -->
-    <a href="https://github.com/networked-aframe/networked-aframe" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-      </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    </style>
-
-    <script>
-      // On mobile remove elements that are resource heavy
-      var isMobile = AFRAME.utils.device.isMobile();
-
-      if (isMobile) {
-        var particles = document.getElementById('particles');
-        particles.parentNode.removeChild(particles);
-      }
-    </script>
 
     <script>
       // Define custom schema for syncing avatar color, set by random-color
-      NAF.schemas.add({
-        template: '#avatar-template',
-        components: [
-          'position',
-          'rotation',
-          {
-            selector: '.head',
-            component: 'material',
-            property: 'color'
-          }
-        ]
-      });
+      // NAF.schemas.add({
+      //   template: '#avatar-template',
+      //   components: [
+      //     'position',
+      //     'rotation',
+      //     {
+      //       selector: '.head',
+      //       component: 'material',
+      //       property: 'color'
+      //     }
+      //   ]
+      // });
 
       // Called by Networked-Aframe when connected to server
-      function onConnect () {
-        console.log("onConnect", new Date());
+      function onConnect() {
+        console.log('onConnect', new Date());
       }
     </script>
   </body>


### PR DESCRIPTION
This closes #325

- added a prettier config with no trailing comma, single quote to match what we had previously but increase to 120 characters per line to have the avatar template entities on single line like we discussed.
- removed the imgur images, plane, sky, lights, particles
- used the arches environment component in all examples
- included the schema hack like I did in the basic.html example
- added a cameraRig to all examples
- removed the github corner on all examples, I left it only on the index.html
- renamed camera-rig to cameraRig, and local-avatar to player in tracked-controllers example so this is the same like the other examples
- added an explicit "adapter: wseasyrtc" in the examples where the adapter wasn't defined