### PR TITLE
Don't build on start but only on install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         run: npm run lint
 
       - name: Check Build
-        run: npm run build
+        run: npm run dist

--- a/docs/release-instructions.md
+++ b/docs/release-instructions.md
@@ -1,12 +1,12 @@
 # Steps to make a new networked-aframe release
 
-- update the version in `src/NafIndex.js` and `package.json`, `git commit -am"bump version to 0.8.0"`
+- update the version in `src/NafIndex.js`, `package-glitch.json` and `package.json`, `git commit -am"bump version to 0.8.0"`
 - run `npm install` and `npm run dist` and commit the files `git commit -am"build dist"`
 - If it's a major version, update the script tag in [README Basic Example](https://github.com/networked-aframe/networked-aframe#basic-example), in the [getting started tutorial](docs/getting-started-local.md) and the networked-aframe dependency version in the package.json snippet. Commit the changes.
 - `git tag 0.8.0` and `git push --tags`
 - `npm login && npm publish`
 - update the [naf-project](https://glitch.com/edit/#!/naf-project) base template on glitch (`package.json` and js links in the head, maybe update the `server.js`)
-- write the release notes in `docs/RELEASE_NOTES.md` and on the [github release](https://github.com/networked-aframe/networked-aframe/releases)
+- create a [github release](https://github.com/networked-aframe/networked-aframe/releases) and write the release notes there
 - resync the [naf-examples](https://glitch.com/edit/#!/naf-examples) project on glitch, in the bottom left, click on Tools then Terminal
 
 and type:
@@ -14,10 +14,6 @@ and type:
     git remote add upstream https://github.com/networked-aframe/networked-aframe.git
     git fetch upstream
     git reset --hard upstream/master
+    cp package-glitch.json package.json
+    rm package-lock.json
     refresh
-
-edit `package.json` to use node 16 with npm 7 supporting lockfile v2 (otherwise glitch will use node 10):
-
-    "engines": {
-      "node": ">=16"
-    }

--- a/package-glitch.json
+++ b/package-glitch.json
@@ -1,0 +1,26 @@
+{
+  "name": "naf-examples",
+  "version": "0.10.0",
+  "description": "Examples of networked-aframe",
+  "main": "./server/easyrtc-server.js",
+  "scripts": {
+    "prepare": "cp -r dist examples",
+    "start": "node ./server/easyrtc-server.js"
+  },
+  "dependencies": {
+    "networked-aframe": "^0.10.0"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "repository": {
+    "url": "https://glitch.com/edit/#!/naf-examples"
+  },
+  "license": "MIT",
+  "keywords": [
+    "node",
+    "glitch",
+    "express"
+  ]
+}
+

--- a/package.json
+++ b/package.json
@@ -10,18 +10,15 @@
     "url": "https://github.com/networked-aframe/networked-aframe/issues"
   },
   "scripts": {
-    "build": "npm run dist && shx cp -r dist examples",
     "dev": "cross-env NODE_ENV=development node ./server/easyrtc-server.js",
     "dev-socketio": "cross-env NODE_ENV=development node ./server/socketio-server.js",
     "dist": "npm run dist:min && npm run dist:max",
     "dist:max": "webpack --config webpack.config.js",
     "dist:min": "webpack --config webpack.prod.config.js",
     "lint": "eslint src examples server tests *.js",
-    "prepare": "npm run dist",
-    "preghpages": "npm run dist && shx rm -rf gh-pages && shx mkdir gh-pages && shx cp -r examples/* gh-pages && shx cp -r dist gh-pages",
-    "ghpages": "npm run preghpages && ghpages -p gh-pages",
-    "start": "npm run build && node ./server/easyrtc-server.js",
-    "start-socketio": "npm run build && node ./server/socketio-server.js",
+    "prepare": "npm run dist && shx cp -r dist examples",
+    "start": "node ./server/easyrtc-server.js",
+    "start-socketio": "node ./server/socketio-server.js",
     "test": "karma start ./tests/unit/karma.conf.js",
     "test:firefox": "karma start ./tests/unit/karma.conf.js --browsers Firefox",
     "test:chrome": "karma start ./tests/unit/karma.conf.js --browsers Chrome"

--- a/server/easyrtc-server.js
+++ b/server/easyrtc-server.js
@@ -13,9 +13,8 @@ const port = process.env.PORT || 8080;
 
 // Setup and configure Express http server.
 const app = express();
-app.use(express.static(path.resolve(__dirname, "..", "examples")));
 
-// Serve the example and build the bundle in development.
+// Serve the bundle in-memory in development (needs to be before the express.static)
 if (process.env.NODE_ENV === "development") {
   const webpackMiddleware = require("webpack-dev-middleware");
   const webpack = require("webpack");
@@ -23,10 +22,13 @@ if (process.env.NODE_ENV === "development") {
 
   app.use(
     webpackMiddleware(webpack(config), {
-      publicPath: "/"
+      publicPath: "/dist/"
     })
   );
 }
+
+// Serve the files from the examples folder
+app.use(express.static(path.resolve(__dirname, "..", "examples")));
 
 // Start Express http server
 const webServer = http.createServer(app);

--- a/server/socketio-server.js
+++ b/server/socketio-server.js
@@ -11,9 +11,8 @@ const port = process.env.PORT || 8080;
 
 // Setup and configure Express http server.
 const app = express();
-app.use(express.static(path.resolve(__dirname, "..", "examples")));
 
-// Serve the example and build the bundle in development.
+// Serve the bundle in-memory in development (needs to be before the express.static)
 if (process.env.NODE_ENV === "development") {
   const webpackMiddleware = require("webpack-dev-middleware");
   const webpack = require("webpack");
@@ -21,10 +20,13 @@ if (process.env.NODE_ENV === "development") {
 
   app.use(
     webpackMiddleware(webpack(config), {
-      publicPath: "/"
+      publicPath: "/dist/"
     })
   );
 }
+
+// Serve the files from the examples folder
+app.use(express.static(path.resolve(__dirname, "..", "examples")));
 
 // Start Express http server
 const webServer = http.createServer(app);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,11 @@
+const path = require("path");
+
 module.exports = {
     entry  : './src/index.js',
     output : {
-        path     : __dirname,
-        filename : './dist/networked-aframe.js'
+        path     : path.resolve(__dirname, 'dist'),
+        publicPath: '/dist/',
+        filename : 'networked-aframe.js'
     },
     mode: 'development',
     module : {


### PR DESCRIPTION
See #347 for context.
I introduced some time ago (in https://github.com/networked-aframe/networked-aframe/commit/017d40cca82b0f7666327e0a14a8f49b3224b2ba and https://github.com/networked-aframe/networked-aframe/commit/a97b5e79dd30785557c2f33d184d3741f8315a14) running `npm run build` as part of `npm start` to be sure to have latest build when using `npm start` instead of `npm run dev`. In retrospect, I think this change was wrong, we shouldn't run a build step on `npm start` (for glitch) so I'm reverting this change.
`npm install` is executing `npm run prepare` that is executing `npm run dist` already. I added the `cp -r dist examples` in the prepare script instead. And I fixed the webpack-dev-server config to use the bundle in-memory and not the one from examples/dist when running `npm run dev` (no need to run `npm run dist` before running `npm run dev`).