### PR TITLE
Fix conflicting button style in aframe inspector

### DIFF
--- a/examples/css/style.css
+++ b/examples/css/style.css
@@ -5,7 +5,7 @@
   left: 3%;
 }
 
-.button {
+.actions .button {
   cursor: pointer;
   background: #fff;
   height: 40px;


### PR DESCRIPTION
The issue was this, aframe inspector is using the button class on the inspector buttons, conflicting with the css rule we have in style.css
![Capture d’écran de 2022-07-28 13-20-29](https://user-images.githubusercontent.com/112249/181493642-e63e680b-d822-430c-b947-9d706b67d1c2.png)

To fix the issue I modified the css rule to target the buttons in the actions div.
If you have some examples that is using the style.css and the button class, be sure to put the buttons in a div with class actions. All the examples are using this construct since #302

```html
<div class="actions">                                                       
  <button id="camera-btn" type="button" class="button">Hide Camera</button> 
</div>
```