### PR TITLE
Less confusing doc with the new introduced networked-hand-controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,12 @@ To sync nested templates setup your HTML nodes like so:
 
 In this example the head/camera, left and right hands will spawn their own templates which will be networked independently of the root player. Note: this parent-child relationship only works between one level, ie. a child entity's direct parent must have the `networked` component.
 
+You need to define your left and right hand templates yourself to show hand models for the other users. Only the position and rotation will be synced to the other users. To sync the hand gesture, see the `networked-hand-controls` component below.
+
 ### Tracked Controllers w/ Synced Gestures
 
-NAF now allows easily adding hand models that show gestures matching to which buttons are touched--so you can point and give a thumbs up or make a fist to other people in the room.
+This is a much simpler alternative to the above.
+NAF allows easily adding hand models visible to the others that show gestures matching to which buttons are touched--so you can point and give a thumbs up or make a fist to other people in the room.
 
 All you have to do is use the built in `networked-hand-controls` component, by adding these two lines as children of your camera rig:
 
@@ -376,6 +379,52 @@ The public schema properties you can set are:
 | oneOf | N/A | ['right', 'left'] | ['highPoly', 'lowPoly', 'toon', 'controller'] | N/A |
 
 Note the 'controller' option--that will use a model of the controller itself, automatically set correctly according to your platform--it will also broadcast model-supported button mesh updates. (Unfortunately, there's currently a bug with the Quest 2 model button meshes, so that one doesn't show any updates.)
+
+The `networked-hand-controls` is replacing completely `hand-controls`, don't use both.
+Also you don't need to define a template, networked schema and add the `networked` component to it, this is all done for you.
+For you to understand, the following is done automatically. You don't need to add that yourself.
+
+```html
+<template id="left-hand-template">
+  <a-entity networked-hand-controls="hand:left"></a-entity>
+</template>
+<template id="right-hand-template">
+  <a-entity networked-hand-controls="hand:right"></a-entity>
+</template>
+```
+
+```javascript
+NAF.schemas.add({
+  template: '#left-hand-template'
+  components: [
+    'position',
+    'rotation',
+    'networked-hand-controls'
+  ]
+});
+NAF.schemas.add({
+  template: '#right-hand-template'
+  components: [
+    'position',
+    'rotation',
+    'networked-hand-controls'
+  ]
+});
+```
+
+and the `networked-hand-controls` component is auto setting
+
+```html
+networked="template:#left-hand-template;attachTemplateToLocal:true"
+```
+
+and
+
+```html
+networked="template:#right-hand-template;attachTemplateToLocal:true"
+```
+
+on the corresponding entity.
 
 ### Sending Custom Messages
 

--- a/README.md
+++ b/README.md
@@ -362,8 +362,16 @@ NAF allows easily adding hand models visible to the others that show gestures ma
 All you have to do is use the built in `networked-hand-controls` component, by adding these two entities as children of your camera rig:
 
 ```html
-<a-entity networked-hand-controls="hand:left" networked="template:#left-hand-default-template"></a-entity>
-<a-entity networked-hand-controls="hand:right" networked="template:#right-hand-default-template"></a-entity>
+<a-entity
+  id="my-tracked-left-hand"
+  networked-hand-controls="hand:left"
+  networked="template:#left-hand-default-template"
+></a-entity>
+<a-entity
+  id="my-tracked-right-hand"
+  networked-hand-controls="hand:right"
+  networked="template:#right-hand-default-template"
+></a-entity
 ```
 
 To see a working demo, check out the [Glitch NAF Tracked Controllers Example](https://naf-examples.glitch.me/tracked-controllers.html).

--- a/README.md
+++ b/README.md
@@ -226,12 +226,11 @@ Templates must only have one root element. When `attachTemplateToLocal` is set t
 </a-entity>
 ```
 
-| Parameter | Description | Default
-| -------- | ------------ | --------------
-| template  | A css selector to a template tag stored in `<a-assets>` | ''
-| attachTemplateToLocal  | Does not attach the template for the local user when set to false. This is useful when there is different behavior locally and remotely. | true
-| persistent | On remote creator (not owner) disconnect, attempts to take ownership of persistent entities rather than delete them | false
-
+| Property              | Description                                                                                                                              | Default Value |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| template              | A css selector to a template tag stored in `<a-assets>`                                                                                  | ''            |
+| attachTemplateToLocal | Does not attach the template for the local user when set to false. This is useful when there is different behavior locally and remotely. | true          |
+| persistent            | On remote creator (not owner) disconnect, attempts to take ownership of persistent entities rather than delete them                      | false         |
 
 ### Deleting Networked Entities
 
@@ -371,12 +370,12 @@ To see a working demo, check out the [Glitch NAF Tracked Controllers Example](ht
 
 The public schema properties you can set are:
 
-| ---- | color | hand | handModelStyle | customHandModelURL |
-| ---- | ----- | ---- | -------------- | ------------ |
-| info | will be set as material color | - | available built-in models from A-Frame | optional custom hand model url |
-| default | 'white' | 'left' | 'highPoly' | '' |
-| type | 'color' | 'string' |  'string' | 'string' |
-| oneOf | N/A | ['right', 'left'] | ['highPoly', 'lowPoly', 'toon', 'controller'] | N/A |
+| Property           | Description                                 | Default Value | Values                              |
+| ------------------ | ------------------------------------------- | ------------- | ----------------------------------- |
+| color              | Will be set as material color               | white         |
+| hand               | Specify if entity is for left or right hand | left          | left, right                         |
+| handModelStyle     | Available built-in models from A-Frame      | highPoly      | highPoly, lowPoly, toon, controller |
+| customHandModelURL | Optional custom hand model url              |               |                                     |
 
 Note the 'controller' option--that will use a model of the controller itself, automatically set correctly according to your platform--it will also broadcast model-supported button mesh updates. (Unfortunately, there's currently a bug with the Quest 2 model button meshes, so that one doesn't show any updates.)
 

--- a/README.md
+++ b/README.md
@@ -359,11 +359,11 @@ You need to define your left and right hand templates yourself to show hand mode
 This is a much simpler alternative to the above.
 NAF allows easily adding hand models visible to the others that show gestures matching to which buttons are touched--so you can point and give a thumbs up or make a fist to other people in the room.
 
-All you have to do is use the built in `networked-hand-controls` component, by adding these two lines as children of your camera rig:
+All you have to do is use the built in `networked-hand-controls` component, by adding these two entities as children of your camera rig:
 
 ```html
-<a-entity id="my-tracked-left-hand" networked-hand-controls="hand:left;"></a-entity>
-<a-entity id="my-tracked-right-hand" networked-hand-controls="hand:right;"></a-entity>
+<a-entity networked-hand-controls="hand:left" networked="template:#left-hand-default-template"></a-entity>
+<a-entity networked-hand-controls="hand:right" networked="template:#right-hand-default-template"></a-entity>
 ```
 
 To see a working demo, check out the [Glitch NAF Tracked Controllers Example](https://naf-examples.glitch.me/tracked-controllers.html).
@@ -380,21 +380,21 @@ The public schema properties you can set are:
 Note the 'controller' option--that will use a model of the controller itself, automatically set correctly according to your platform--it will also broadcast model-supported button mesh updates. (Unfortunately, there's currently a bug with the Quest 2 model button meshes, so that one doesn't show any updates.)
 
 The `networked-hand-controls` is replacing completely `hand-controls`, don't use both.
-Also you don't need to define a template, networked schema and add the `networked` component to it, this is all done for you.
-For you to understand, the following is done automatically. You don't need to add that yourself.
+If you use the networked component as described above, you don't need to define the template and the networked schema for each hand.
+Default templates and networked schemas are already defined as follow:
 
 ```html
-<template id="left-hand-template">
+<template id="left-hand-default-template">
   <a-entity networked-hand-controls="hand:left"></a-entity>
 </template>
-<template id="right-hand-template">
+<template id="right-hand-default-template">
   <a-entity networked-hand-controls="hand:right"></a-entity>
 </template>
 ```
 
 ```javascript
 NAF.schemas.add({
-  template: '#left-hand-template'
+  template: '#left-hand-default-template'
   components: [
     'position',
     'rotation',
@@ -402,7 +402,7 @@ NAF.schemas.add({
   ]
 });
 NAF.schemas.add({
-  template: '#right-hand-template'
+  template: '#right-hand-default-template'
   components: [
     'position',
     'rotation',
@@ -410,20 +410,6 @@ NAF.schemas.add({
   ]
 });
 ```
-
-and the `networked-hand-controls` component is auto setting
-
-```html
-networked="template:#left-hand-template;attachTemplateToLocal:true"
-```
-
-and
-
-```html
-networked="template:#right-hand-template;attachTemplateToLocal:true"
-```
-
-on the corresponding entity.
 
 ### Sending Custom Messages
 

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -86,11 +86,16 @@
           visible="false"
         >
         </a-entity>
-        <!-- here we add the user's local hands! These two lines are all that is needed. -->
-        <a-entity id="my-tracked-left-hand" networked-hand-controls="hand:left; color:gold;"></a-entity>
+        <!-- here we add the user's local hands! These two entities are all that is needed. -->
+        <a-entity
+          id="my-tracked-left-hand"
+          networked-hand-controls="hand:left;color:gold;"
+          networked="template:#left-hand-default-template"
+        ></a-entity>
         <a-entity
           id="my-tracked-right-hand"
-          networked-hand-controls="hand:right; handModelStyle: controller;"
+          networked-hand-controls="hand:right;handModelStyle:controller;"
+          networked="template:#right-hand-default-template"
         ></a-entity>
       </a-entity>
     </a-scene>

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -20,20 +20,20 @@ function addHandTemplate(hand) {
   let templateOuter = document.createElement('template');
   let templateInner = document.createElement('a-entity');
 
-  templateOuter.id = `${hand}-hand-template`;
-  templateInner.setAttribute('networked-hand-controls',`hand: ${hand}`);
+  templateOuter.id = `${hand}-hand-default-template`;
+  templateInner.setAttribute('networked-hand-controls', `hand: ${hand}`);
 
   templateOuter.appendChild(templateInner);
 
-  NAF.schemas.schemaDict[`#${hand}-hand-template`] = {
-    template: `#${hand}-hand-template`,
+  NAF.schemas.schemaDict[`#${hand}-hand-default-template`] = {
+    template: `#${hand}-hand-default-template`,
     components: [
       'position',
       'rotation',
       'networked-hand-controls',
     ]
   };
-  NAF.schemas.templateCache[`#${hand}-hand-template`] = templateOuter;
+  NAF.schemas.templateCache[`#${hand}-hand-default-template`] = templateOuter;
 }
 ["left","right"].forEach(addHandTemplate);
 
@@ -68,39 +68,39 @@ AFRAME.registerComponent('networked-hand-controls', {
 
   init() {
     this.setup();
-    this.el.setAttribute('networked', 'template', `#${this.data.hand}-hand-template`);
-    this.el.setAttribute('networked', 'attachTemplateToLocal', true);
-    
-    this.local = this.el.components.networked.createdByMe();
 
-    if (this.local) {
-      for (const evtName in this.buttonEventMap) {
-        this.eventFunctionMap[this.data.hand][evtName] = this.handleButton.bind(this, ...this.buttonEventMap[evtName]);
-      }
-      for (const evtName in this.visibleListeners) {
-        this.eventFunctionMap[this.data.hand][evtName] = this.visibleListeners[evtName].bind(this);
-      }
+    for (const evtName in this.buttonEventMap) {
+      this.eventFunctionMap[this.data.hand][evtName] = this.handleButton.bind(this, ...this.buttonEventMap[evtName]);
     }
-    else {
-      this.el.classList.add('naf-remote-hand');
+    for (const evtName in this.visibleListeners) {
+      this.eventFunctionMap[this.data.hand][evtName] = this.visibleListeners[evtName].bind(this);
     }
 
     if (this.data.handModelStyle !== "controller") {
       this.addHandModel();
     }
-    if (this.local) {
-      this.addControllerComponents(this.data.handModelStyle == "controller");
-    }
+
+    NAF.utils.getNetworkedEntity(this.el).then((networkedEl) => {
+      // Here networkedEl may be different than this.el if we don't use nested
+      // networked components for hands.
+      this.local = networkedEl.components.networked.createdByMe();
+    }).catch(() => {
+      this.local = true;
+    }).then(() => {
+      if (this.local) {
+        this.addControllerComponents(this.data.handModelStyle === "controller");
+      }
+    });
   },
 
   play() {
     if (this.local) {
-        this.addEventListeners(); 
+      this.addEventListeners();
     }
   },
 
   pause() {
-    if (this.local) {    
+    if (this.local) {
       this.removeEventListeners();
     }
   },
@@ -119,7 +119,7 @@ AFRAME.registerComponent('networked-hand-controls', {
         oldData.handModelStyle !== this.data.handModelStyle
       ) {
       // first, remove old model
-      this.el.removeObject3D(this.str.mesh);
+      if (this.getMesh()) this.el.removeObject3D(this.str.mesh);
       ['gltf-model','obj-model'].forEach(modelComponent => {
         if (this.el.components[modelComponent]) {
           this.el.removeAttribute(modelComponent);
@@ -134,12 +134,14 @@ AFRAME.registerComponent('networked-hand-controls', {
         // this.el.setAttribute(this.data.controllerComponent, 'model', true)
 
         // so we first remove the controller component
-        if (this.el.components[this.data.controllerComponent]) {
+        if (this.data.controllerComponent && this.el.components[this.data.controllerComponent]) {
           this.el.removeAttribute(this.data.controllerComponent);
         }
 
         if (!this.local) {
-          this.injectRemoteControllerModel();
+          if (!this.injectedController && this.data.controllerComponent && this.data.webxrControllerProfiles[0]) {
+            this.injectRemoteControllerModel();
+          }
         }
         else {
           this.addControllerComponents(true);
@@ -201,17 +203,19 @@ AFRAME.registerComponent('networked-hand-controls', {
       this.el.setObject3D(this.str.mesh, newMesh);
 
       const handMaterial = newMesh.children[1].material;
-      handMaterial.color = new THREE.Color(this.data.handColor);
+      handMaterial.color = new THREE.Color(this.data.color);
+      this.el.sceneEl.systems.renderer.applyColorCorrection(handMaterial.color);
       newMesh.position.set(0, 0, 0);
       newMesh.rotation.set(0, 0, handModelOrientation);
-
-      this.updateHandMeshColor();
     });
   },
 
   updateHandMeshColor() {
-    this.getMesh().children[1].material.color.set(this.data.color);
-    this.el.sceneEl.systems.renderer.applyColorCorrection(this.getMesh().children[1].material.color);
+    const mesh = this.getMesh();
+    if (!mesh) return;
+    const handMaterial = mesh.children[1].material;
+    handMaterial.color.set(this.data.color);
+    this.el.sceneEl.systems.renderer.applyColorCorrection(handMaterial.color);
   },
 
   controllerComponents: [

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -69,13 +69,6 @@ AFRAME.registerComponent('networked-hand-controls', {
   init() {
     this.setup();
 
-    for (const evtName in this.buttonEventMap) {
-      this.eventFunctionMap[this.data.hand][evtName] = this.handleButton.bind(this, ...this.buttonEventMap[evtName]);
-    }
-    for (const evtName in this.visibleListeners) {
-      this.eventFunctionMap[this.data.hand][evtName] = this.visibleListeners[evtName].bind(this);
-    }
-
     if (this.data.handModelStyle !== "controller") {
       this.addHandModel();
     }
@@ -89,6 +82,13 @@ AFRAME.registerComponent('networked-hand-controls', {
     }).then(() => {
       if (this.local) {
         this.addControllerComponents(this.data.handModelStyle === "controller");
+        // Bind all functions, the listeners are only registered later for local avatar.
+        for (const evtName in this.buttonEventMap) {
+          this.eventFunctionMap[this.data.hand][evtName] = this.handleButton.bind(this, ...this.buttonEventMap[evtName]);
+        }
+        for (const evtName in this.visibleListeners) {
+          this.eventFunctionMap[this.data.hand][evtName] = this.visibleListeners[evtName].bind(this);
+        }
       } else {
         // Adding a class to easily see what the entity is in the aframe
         // inspector. This is shown in the class field in the panel after you

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -25,15 +25,16 @@ function addHandTemplate(hand) {
 
   templateOuter.appendChild(templateInner);
 
-  NAF.schemas.schemaDict[`#${hand}-hand-default-template`] = {
-    template: `#${hand}-hand-default-template`,
+  const refTemplateId = `#${templateOuter.id}`;
+  NAF.schemas.schemaDict[refTemplateId] = {
+    template: refTemplateId,
     components: [
       'position',
       'rotation',
       'networked-hand-controls',
     ]
   };
-  NAF.schemas.templateCache[`#${hand}-hand-default-template`] = templateOuter;
+  NAF.schemas.templateCache[refTemplateId] = templateOuter;
 }
 ["left","right"].forEach(addHandTemplate);
 

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -69,6 +69,7 @@ AFRAME.registerComponent('networked-hand-controls', {
 
   init() {
     this.setup();
+    this.rendererSystem = this.el.sceneEl.systems.renderer;
 
     if (this.data.handModelStyle !== "controller") {
       this.addHandModel();
@@ -210,7 +211,7 @@ AFRAME.registerComponent('networked-hand-controls', {
 
       const handMaterial = newMesh.children[1].material;
       handMaterial.color = new THREE.Color(this.data.color);
-      this.el.sceneEl.systems.renderer.applyColorCorrection(handMaterial.color);
+      this.rendererSystem.applyColorCorrection(handMaterial.color);
       newMesh.position.set(0, 0, 0);
       newMesh.rotation.set(0, 0, handModelOrientation);
     });
@@ -221,7 +222,7 @@ AFRAME.registerComponent('networked-hand-controls', {
     if (!mesh) return;
     const handMaterial = mesh.children[1].material;
     handMaterial.color.set(this.data.color);
-    this.el.sceneEl.systems.renderer.applyColorCorrection(handMaterial.color);
+    this.rendererSystem.applyColorCorrection(handMaterial.color);
   },
 
   controllerComponents: [

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -89,6 +89,11 @@ AFRAME.registerComponent('networked-hand-controls', {
     }).then(() => {
       if (this.local) {
         this.addControllerComponents(this.data.handModelStyle === "controller");
+      } else {
+        // Adding a class to easily see what the entity is in the aframe
+        // inspector. This is shown in the class field in the panel after you
+        // click the entity.
+        this.el.classList.add('naf-remote-hand');
       }
     });
   },


### PR DESCRIPTION
The networked-hand-controls component introduced in  #355 and #358 is auto creating the template, networked schema and networked component on the corresponding entity. This was apparently confusing for some users, who mixed the old approach and the new component.
I already committed directly on master moving the new section up without changes https://github.com/networked-aframe/networked-aframe/commit/e81604b20c36218d86530d64554ad50c31ea0dc6 and fixed wrong param custom hand model param https://github.com/networked-aframe/networked-aframe/commit/32651f3bd18738801b079c2f468b9cd5baa263c8
In this PR I added some explanation to better understand the difference between hand-controls with custom templates and the new networked-hand-controls.

But thinking about it, We maybe shouldn't auto create the template, schema, networked component if the user specified it themself, but the way we create it it's not actually possible to check if the user defined it themself. They may want to add additional component to the networked schema, and currently I don't think it's possible.
I'm not sure auto creating all that to simplify the developer experience is actually good, because we actually need to explain in the documentation what's going on behind the scene, otherwise the developer is attaching the networked component and creating the templates themself and not understanding why they have issues.
What's your thoughts @kylebakerio on this?
