### PR TITLE
Better default schema with the requiresNetworkUpdate optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,16 +327,18 @@ and rotation precision of 0.5 degree, use it like this:
   template: '#avatar-template',
   components: [
     {
-      component: "position",
+      component: 'position',
       requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
     },
     {
-      component: "rotation",
+      component: 'rotation',
       requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
     }
   ]
 }
 ```
+
+The default schema that sync position and rotation uses the above optimization since version 0.11.0.
 
 ### Syncing nested templates - eg. hands
 
@@ -404,16 +406,28 @@ Default templates and networked schemas are already defined as follow:
 NAF.schemas.add({
   template: '#left-hand-default-template'
   components: [
-    'position',
-    'rotation',
+    {
+      component: 'position',
+      requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+    },
+    {
+      component: 'rotation',
+      requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+    },
     'networked-hand-controls'
   ]
 });
 NAF.schemas.add({
   template: '#right-hand-default-template'
   components: [
-    'position',
-    'rotation',
+    {
+      component: 'position',
+      requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+    },
+    {
+      component: 'rotation',
+      requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+    },
     'networked-hand-controls'
   ]
 });

--- a/src/Schemas.js
+++ b/src/Schemas.js
@@ -11,8 +11,14 @@ class Schemas {
     return {
       template: name,
       components: [
-        'position',
-        'rotation',
+        {
+          component: 'position',
+          requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+        },
+        {
+          component: 'rotation',
+          requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+        }
       ]
     }
   }

--- a/src/components/networked-hand-controls.js
+++ b/src/components/networked-hand-controls.js
@@ -29,9 +29,15 @@ function addHandTemplate(hand) {
   NAF.schemas.schemaDict[refTemplateId] = {
     template: refTemplateId,
     components: [
-      'position',
-      'rotation',
-      'networked-hand-controls',
+      {
+        component: 'position',
+        requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+      },
+      {
+        component: 'rotation',
+        requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+      },
+      'networked-hand-controls'
     ]
   };
   NAF.schemas.templateCache[refTemplateId] = templateOuter;


### PR DESCRIPTION
Use better default schema with the requiresNetworkUpdate optimization for position and rotation.
Use the same optimization for the default schema used by networked-hand-controls.
As discussed in https://github.com/networked-aframe/networked-aframe/pull/362#issuecomment-1244785047