### PR TITLE
sync quaternion instead of euler

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -41,7 +41,8 @@ class NetworkEntities {
     var hasRotation = componentData['rotation'];
     if (hasRotation) {
       var rotation = componentData.rotation;
-      entity.setAttribute('rotation', rotation);
+      // rotation is really the quaternion here
+      entity.object3D.quaternion.copy(rotation);
     }
   }
 

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -409,7 +409,7 @@ AFRAME.registerComponent('networked', {
       if (this.networkUpdatePredicates[i](syncedComponentData) || fullSync) {
         componentsData = componentsData || {};
         if (componentName === 'rotation') {
-          // We compared the rotation, but we are sending actually the quaternion.
+          // We compared the rotation, but we actually send the quaternion.
           // JSON.stringify(new THREE.Quaternion(0,1,0,1)) gives '{"_x": 0,"_y": 1,"_z": 0,"_w": 1}' with "_" for each key
           // so we need to create an object for it to work properly. THREE.Vector3 doesn't have this issue.
           const q = componentElement.object3D.quaternion;


### PR DESCRIPTION
Sync quaternion instead of the rotation euler to fix some rotation issues with the YXZ or XYZ euler order.
I didn't fix the tests yet.
@kylebakerio with that does it fix your rotation issues?