### PR TITLE
Allow networked entities to become children of a non-networked parent

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -100,6 +100,8 @@
       <a-entity environment="preset:starry;groundColor:#000000;"></a-entity>
       <a-entity light="type:ambient;intensity:0.5"></a-entity>
 
+      <a-box id="platform" color="tomato" depth="10" height=".5" width="10" position="0 10 0">
+
       <!--   Here we declare only the local user's avatar, which we then broadcast to other users     -->
       <!--   The 'spawn-in-circle' component will set the position and rotation of #rig;
              because this entity also has the networked component, and position and rotation are tracked by default,
@@ -108,7 +110,7 @@
              including all applicable child elements. However, because we don't need to see our own avatar, we use the
              `attachTemplateToLocal:false` option. This makes our local copies invisible on our machine, but visible on everyone else's.
       -->
-      <a-entity id="rig" movement-controls="fly:true;" spawn-in-circle="radius:3" networked="template:#rig-template;">
+      <a-entity id="rig" movement-controls="fly:true;" spawn-in-circle="radius:3" networked="template:#rig-template; attachToParentId:platform;">
         <!-- Here we add the camera. Adding the camera within a 'rig' is standard practice.
          We set the camera to head height for e.g. computer users, but otherwise never touch it again; if the user enters VR,
          its rotation and position will be updated by the headset in VR. If we need to touch the user's position
@@ -125,6 +127,8 @@
         >
         </a-entity>
       </a-entity>
+
+      </a-box>
     </a-scene>
 
     <script>

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -88,6 +88,7 @@ class NetworkEntities {
 
   receiveFirstUpdateFromEntity(entityData) {
     var parent = entityData.parent;
+    var attachToParentId = entityData.attachToParentId;
     var networkId = entityData.networkId;
 
     var parentNotCreatedYet = parent && !this.hasEntity(parent);
@@ -96,7 +97,7 @@ class NetworkEntities {
     } else {
       var remoteEntity = this.createRemoteEntity(entityData);
       this.createAndAppendChildren(networkId, remoteEntity);
-      this.addEntityToPage(remoteEntity, parent);
+      this.addEntityToPage(remoteEntity, parent, attachToParentId);
     }
   }
 
@@ -121,9 +122,11 @@ class NetworkEntities {
     }
   }
 
-  addEntityToPage(entity, parentId) {
+  addEntityToPage(entity, parentId, attachToParentId) {
     if (this.hasEntity(parentId)) {
       this.addEntityToParent(entity, parentId);
+    } else if (attachToParentId) {
+      this.addEntityToParentId(entity, attachToParentId)
     } else {
       this.addEntityToSceneRoot(entity);
     }
@@ -131,6 +134,16 @@ class NetworkEntities {
 
   addEntityToParent(entity, parentId) {
     this.entities[parentId].appendChild(entity);
+  }
+
+  addEntityToParentId(el, attachToParentId) {
+    var parent = document.querySelector(`#${attachToParentId}`);
+    if (!parent) {
+      NAF.log.warn('Tried to add entity to parent, but parent with id', attachToParentId,
+        'is not in the scene');
+      return;
+    }
+    parent.appendChild(el);
   }
 
   addEntityToSceneRoot(el) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -117,6 +117,7 @@ AFRAME.registerComponent('networked', {
   schema: {
     template: {default: ''},
     attachTemplateToLocal: { default: true },
+    attachToParentId: { default: '' },
     persistent: { default: false },
 
     networkId: {default: ''},
@@ -427,6 +428,7 @@ AFRAME.registerComponent('networked', {
     syncData.template = data.template;
     syncData.persistent = data.persistent;
     syncData.parent = this.getParentId();
+    syncData.attachToParentId = data.attachToParentId;
     syncData.components = components;
     syncData.isFirstSync = !!isFirstSync;
     return syncData;


### PR DESCRIPTION
## What

Here we add the ability for networked entities to become childeren of non-networked entities (Ie, allow them to end up somewhere other than the root a-scene) 

## Why

For example, imagie each client has a local platform that is _not_ networked, but we want entities to become childeren off. Right now there is no way from my understanding to do this within the general API. 

## Before

You can see the other client ends up below the platform ( because they are not a child of the platform)

https://user-images.githubusercontent.com/12666226/224524346-ba26c6d1-ce85-47c6-b855-40c01aac1ea2.mp4


## After


The other client ends up on the platform (because it is a child of it)


https://user-images.githubusercontent.com/12666226/224524353-ae67b9b6-147e-43a2-b717-6b30d6acdade.mp4

