### PR TITLE
Fix screen share stop and restart (fix #299 #402)

### DIFF
--- a/examples/basic-multi-streams.html
+++ b/examples/basic-multi-streams.html
@@ -57,7 +57,8 @@
               width="2"
               height="1"
               position="0 .7 -0.001"
-              material="side: back"
+              rotation="0 -180 0"
+              material="side: front"
               networked-video-source="streamName: screen"
             ></a-plane>
           </a-entity>
@@ -128,6 +129,17 @@
           } else {
             navigator.mediaDevices.getDisplayMedia().then((stream) => {
               NAF.connection.adapter.addLocalMediaStream(stream, 'screen');
+              stream.getVideoTracks().forEach((track) => {
+                track.addEventListener(
+                  'ended',
+                  () => {
+                    NAF.connection.adapter.removeLocalMediaStream('screen');
+                    screenEnabled = false;
+                    screenBtnEle.textContent = 'Share screen';
+                  },
+                  { once: true }
+                );
+              });
               screenEnabled = true;
               screenBtnEle.textContent = 'Stop Screen';
             });
@@ -135,11 +147,5 @@
         });
       }
     </script>
-    <!--
-      Known issues with this demo, some cases are not handled:
-      - If participant A shares their screen, the partipant B sees the other participant's screen.
-        When participant A stops their screen share, the other participant will see a frozen screen, the last image received.
-      - If participant A starts screen share, stops, and restarts the screen share, the other participant won't see it.
-    -->
   </body>
 </html>

--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -271,6 +271,7 @@ class EasyRtcAdapter extends NoOpAdapter {
       // Resolve the promise for the user's media stream by StreamName if it exists.
       if (pendingMediaRequests && pendingMediaRequests[streamName]) {
         pendingMediaRequests[streamName].resolve(stream);
+        delete pendingMediaRequests[streamName];
       }
     }
   }


### PR DESCRIPTION
Changes proposed:
- Rotate screen plane by 180 degrees, the screen share was reversed (see modified example)
- Handle stopping screenshare from browser button (video track ended event) (see the added code in the example)
- In the easyrtc adapter, properly clean up pendingMediaRequests['screen'] promise to be able to get the new media stream when the video track end and a new one is added later.
- In networked-video-source component, listen on remotetrack to detect that the stream closed (may not be the right easyrtc api to use, but that works) to clean the video texture so the plane comes back to the defined color (white), and run again getMediaStream to wait on new remote stream.