### PR TITLE
Add networked hand tracking component

### DIFF
--- a/src/components/networked-hand-tracking.js
+++ b/src/components/networked-hand-tracking.js
@@ -1,0 +1,34 @@
+﻿/* global AFRAME */
+
+AFRAME.registerComponent('networked-hand-tracking', {
+    dependencies: ['hand-tracking-controls'],
+
+    schema: {
+        options: { default: 'template:#hand-joint-template; attachTemplateToLocal:false' }
+    },
+
+    init: function () {
+        var el = this.el;
+        this.trackingControls = el.components['hand-tracking-controls'];
+
+        this.onExitVR = AFRAME.utils.bind(this.onExitVR, this);
+        el.sceneEl.addEventListener('exit-vr', this.onExitVR);
+    },
+
+    tick: function () {
+        var jointEls = this.trackingControls.jointEls;
+
+        for (var i = 0; i < jointEls.length; i++) {
+            jointEls[i].setAttribute('networked', this.data.options);
+        }
+    },
+
+    onExitVR: function () {
+        var jointEls = this.trackingControls.jointEls;
+        this.trackingControls.jointEls = [];
+
+        for (var i = 0; i < jointEls.length; i++) {
+            jointEls[i].removeAttribute('networked');
+        }
+    },
+});

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ require('./components/networked');
 require('./components/networked-audio-source');
 require('./components/networked-video-source');
 require('./components/networked-hand-controls');
+require('./components/networked-hand-tracking');


### PR DESCRIPTION
Hi, thanks for the networked component.
We're adding it to the [XR# CommunityToolkit](https://github.com/XRSharp/XRSharp.CommunityToolkit). So multi-user experience would quickly be available for C# developers.

It would be really nice to have hand-tracking shared between users. 
Here is a simple component that adds `networked` attribute for every hand joint. Only `modelStyle: dots` is supported.

Please check example project: https://glitch.com/edit/#!/naf-hand-tracking

Related issue #394 