### PR TITLE
Specify colorSpace srgb for video texture for compatibility with aframe 1.5.0 (fix #444)

### DIFF
--- a/src/components/networked-video-source.js
+++ b/src/components/networked-video-source.js
@@ -59,6 +59,7 @@ AFRAME.registerComponent('networked-video-source', {
 
         const mesh = this.el.getObject3D('mesh');
         mesh.material.map = this.videoTexture;
+        mesh.material.map.colorSpace = THREE.SRGBColorSpace;
         mesh.material.needsUpdate = true;
 
         // Listen for the 'removetrack' event on the MediaStream


### PR DESCRIPTION
Specify colorSpace srgb for video texture for compatibility with aframe 1.5.0 (fix #444)
Thanks @Turtleted21 for the investigation.