### PR TITLE
Avoid allocations in tick

### DIFF
--- a/examples/basic-chat.html
+++ b/examples/basic-chat.html
@@ -13,7 +13,7 @@
     <script src="/dist/networked-aframe.js"></script>
 
     <!--    used for flying in this demo  -->
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.2/dist/aframe-extras.controls.min.js"></script>
 
     <!--   used for the pretty environment   -->
     <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.3.7/dist/aframe-environment-component.min.js"></script>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -13,7 +13,7 @@
     <script src="/dist/networked-aframe.js"></script>
 
     <!--    used for flying in this demo  -->
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.2/dist/aframe-extras.controls.min.js"></script>
 
     <!--   used for the pretty environment   -->
     <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.3.7/dist/aframe-environment-component.min.js"></script>

--- a/examples/nametag.html
+++ b/examples/nametag.html
@@ -11,7 +11,7 @@
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.2/dist/aframe-extras.controls.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.3.7/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
 

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -11,7 +11,7 @@
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.2/dist/aframe-extras.controls.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.3.7/dist/aframe-environment-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-randomizer-components@3.0.2/dist/aframe-randomizer-components.min.js"></script>

--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -9,6 +9,7 @@ class EasyRtcAdapter extends NoOpAdapter {
     this.easyrtc = easyrtc || window.easyrtc;
     this.app = "default";
     this.room = "default";
+    this.destination = {targetRoom: this.room};
 
     this.mediaStreams = {};
     this.remoteClients = {};
@@ -46,6 +47,7 @@ class EasyRtcAdapter extends NoOpAdapter {
 
   setRoom(roomName) {
     this.room = roomName;
+    this.destination.targetRoom = this.room;
     this.easyrtc.joinRoom(roomName, null);
   }
 
@@ -175,8 +177,7 @@ class EasyRtcAdapter extends NoOpAdapter {
   }
 
   broadcastDataGuaranteed(dataType, data) {
-    var destination = { targetRoom: this.room };
-    this.easyrtc.sendDataWS(destination, dataType, data);
+    this.easyrtc.sendDataWS(this.destination, dataType, data);
   }
 
   getConnectStatus(clientId) {

--- a/src/adapters/WsEasyRtcAdapter.js
+++ b/src/adapters/WsEasyRtcAdapter.js
@@ -9,6 +9,7 @@ class WsEasyRtcInterface extends NoOpAdapter {
     this.easyrtc = easyrtc || window.easyrtc;
     this.app = 'default';
     this.room = 'default';
+    this.destination = {targetRoom: this.room};
 
     this.connectedClients = [];
 
@@ -28,6 +29,7 @@ class WsEasyRtcInterface extends NoOpAdapter {
 
   setRoom(roomName) {
     this.room = roomName;
+    this.destination.targetRoom = this.room;
     this.easyrtc.joinRoom(roomName, null);
   }
 
@@ -118,8 +120,7 @@ class WsEasyRtcInterface extends NoOpAdapter {
   }
 
   broadcastData(dataType, data) {
-    var destination = {targetRoom: this.room};
-    this.easyrtc.sendDataWS(destination, dataType, data);
+    this.easyrtc.sendDataWS(this.destination, dataType, data);
   }
 
   broadcastDataGuaranteed(dataType, data) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -62,6 +62,11 @@ function warnOnInvalidNetworkUpdate() {
   NAF.log.warn(`Received invalid network update.`);
 }
 
+function clearObject(obj) {
+  for (const key in obj) { delete obj[key]; }
+  return obj;
+}
+
 AFRAME.registerSystem("networked", {
   init() {
     // An array of "networked" component instances.
@@ -158,6 +163,7 @@ AFRAME.registerComponent('networked', {
     this.onConnected = this.onConnected.bind(this);
 
     this.syncData = {};
+    this.componentsData = {};
     this.componentSchemas =  NAF.schemas.getComponents(this.data.template);
     this.cachedElements = new Array(this.componentSchemas.length);
     this.networkUpdatePredicates = this.componentSchemas.map(x => (x.requiresNetworkUpdate && x.requiresNetworkUpdate()) || defaultRequiresUpdate());
@@ -395,7 +401,7 @@ AFRAME.registerComponent('networked', {
 
       if (!componentElement) {
         if (fullSync) {
-          componentsData = componentsData || {};
+          componentsData = componentsData || clearObject(this.componentsData);
           componentsData[i] = null;
         }
         continue;
@@ -406,7 +412,7 @@ AFRAME.registerComponent('networked', {
 
       if (componentData === null) {
         if (fullSync) {
-          componentsData = componentsData || {};
+          componentsData = componentsData || clearObject(this.componentsData);
           componentsData[i] = null;
         }
         continue;
@@ -417,7 +423,7 @@ AFRAME.registerComponent('networked', {
       // Use networkUpdatePredicate to check if the component needs to be updated.
       // Call networkUpdatePredicate first so that it can update any cached values in the event of a fullSync.
       if (this.networkUpdatePredicates[i](syncedComponentData) || fullSync) {
-        componentsData = componentsData || {};
+        componentsData = componentsData || clearObject(this.componentsData);
         componentsData[i] = syncedComponentData;
       }
     }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -82,13 +82,15 @@ AFRAME.registerSystem("networked", {
   },
 
   tick: (function() {
+    // "d" is an array of entity datas per entity in this.components.
+    const data = { d: [] };
 
     return function() {
       if (!NAF.connection.adapter) return;
       if (this.el.clock.elapsedTime < this.nextSyncTime) return;
 
-      // "d" is an array of entity datas per entity in this.components.
-      const data = { d: [] };
+      // Reset the "d" array
+      data.d.length = 0;
 
       for (let i = 0, l = this.components.length; i < l; i++) {
         const c = this.components[i];


### PR DESCRIPTION
- Avoid allocation of an object and array on system tick for the data.d structure.
- Avoid allocation of an object when an entity has components that have changes or fullsync
- Reuse destination object in broadcastData for (ws)easyrtc adapters
- Update to aframe-extras 7.5.2 that has a fix to not allocate an array and object on each tick in gamepad-controls https://github.com/c-frame/aframe-extras/pull/452