### PR TITLE
Put back ['position', 'rotation'] without requiresNetworkUpdate for default schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,6 @@ and rotation precision of 0.5 degree, use it like this:
 }
 ```
 
-The default schema that sync position and rotation uses the above optimization since version 0.11.0.
-
 ### Syncing nested templates - eg. hands
 
 To sync nested templates setup your HTML nodes like so:

--- a/examples/360.html
+++ b/examples/360.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/basic-ar.html
+++ b/examples/basic-ar.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/basic-audio.html
+++ b/examples/basic-audio.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/basic-chat.html
+++ b/examples/basic-chat.html
@@ -84,8 +84,14 @@
               // position and rotation are added by default if we don't include a template, but since
               // we also want to sync the color, we need to specify a custom template; if we didn't
               // include position and rotation in this custom template, they'd not be synced.
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
 
               // this is how we sync a particular property of a particular component for a particular
               // child element of template instances.

--- a/examples/basic-events.html
+++ b/examples/basic-events.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/basic-multi-streams.html
+++ b/examples/basic-multi-streams.html
@@ -16,7 +16,16 @@
         if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
-            components: ['position', 'rotation']
+            components: [
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              }
+            ]
           });
         }
         const components = NAF.schemas.getComponentsOriginal(template);

--- a/examples/basic-persistent.html
+++ b/examples/basic-persistent.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/basic-video.html
+++ b/examples/basic-video.html
@@ -16,7 +16,16 @@
         if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
-            components: ['position', 'rotation']
+            components: [
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              }
+            ]
           });
         }
         const components = NAF.schemas.getComponentsOriginal(template);

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -44,8 +44,14 @@
               // position and rotation are added by default if we don't include a template, but since
               // we also want to sync the color, we need to specify a custom template; if we didn't
               // include position and rotation in this custom template, they'd not be synced.
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
 
               // this is how we sync a particular property of a particular component for a particular
               // child element of template instances.

--- a/examples/child-entities.html
+++ b/examples/child-entities.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/disconnect.html
+++ b/examples/disconnect.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/google-blocks.html
+++ b/examples/google-blocks.html
@@ -16,7 +16,16 @@
         if (!NAF.schemas.hasTemplate('#avatar-template')) {
           NAF.schemas.add({
             template: '#avatar-template',
-            components: ['position', 'rotation']
+            components: [
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              }
+            ]
           });
         }
         const components = NAF.schemas.getComponentsOriginal(template);

--- a/examples/nametag.html
+++ b/examples/nametag.html
@@ -23,8 +23,14 @@
           NAF.schemas.add({
             template: '#head-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
 
               // In this example, we don't sync the material.color itself, like the basic example;
               // we instead sync player-info, which includes color setting + updating.

--- a/examples/ownership-transfer.html
+++ b/examples/ownership-transfer.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/persistent-peer-to-peer.html
+++ b/examples/persistent-peer-to-peer.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/shooter.html
+++ b/examples/shooter.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -25,8 +25,14 @@
           NAF.schemas.add({
             template: '#head-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/examples/webrtc.html
+++ b/examples/webrtc.html
@@ -17,8 +17,14 @@
           NAF.schemas.add({
             template: '#avatar-template',
             components: [
-              'position',
-              'rotation',
+              {
+                component: 'position',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
+              },
+              {
+                component: 'rotation',
+                requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
+              },
               {
                 selector: '.head',
                 component: 'material',

--- a/src/Schemas.js
+++ b/src/Schemas.js
@@ -10,16 +10,7 @@ class Schemas {
   createDefaultSchema(name) {
     return {
       template: name,
-      components: [
-        {
-          component: 'position',
-          requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.001)
-        },
-        {
-          component: 'rotation',
-          requiresNetworkUpdate: NAF.utils.vectorRequiresUpdate(0.5)
-        }
-      ]
+      components: ['position', 'rotation']
     }
   }
 


### PR DESCRIPTION
Put back ['position', 'rotation'] without requiresNetworkUpdate for default schema, changes that were done in #367 for the 0.11.0 release were not working.
Also better to define yourself requiresNetworkUpdate to use vectorRequiresUpdate over the default defaultRequiresUpdate because it may have an impact on cpu performance over large number of owned entities (1-2ms with 3000 entities), defaultRequiresUpdate may be better for entities that aren't moving much, vectorRequiresUpdate is best used to reduce the sent messages and so the used bandwidth of moving avatars.

Update all examples to use NAF.utils.vectorRequiresUpdate for position and rotation for avatar-template.