### PR TITLE
Add compatibility with socket.io 4.8.1 in socketio-server.js

### DIFF
--- a/server/.prettierrc.json
+++ b/server/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "trailingComma": "none",
+  "singleQuote": false
+}

--- a/server/socketio-server.js
+++ b/server/socketio-server.js
@@ -37,12 +37,12 @@ const io = require("socket.io")(webServer);
 
 const rooms = new Map();
 
-io.on("connection", socket => {
+io.on("connection", (socket) => {
   console.log("user connected", socket.id);
 
   let curRoom = null;
 
-  socket.on("joinRoom", data => {
+  socket.on("joinRoom", (data) => {
     const { room } = data;
 
     curRoom = room;
@@ -82,7 +82,7 @@ io.on("connection", socket => {
           occupants: {},
           occupantsCount: 0
         };
-        rooms.set(curRoom, roomInfo)
+        rooms.set(curRoom, roomInfo);
       }
     }
 
@@ -98,16 +98,16 @@ io.on("connection", socket => {
     io.in(curRoom).emit("occupantsChanged", { occupants });
   });
 
-  socket.on("send", data => {
+  socket.on("send", (data) => {
     io.to(data.to).emit("send", data);
   });
 
-  socket.on("broadcast", data => {
+  socket.on("broadcast", (data) => {
     socket.to(curRoom).broadcast.emit("broadcast", data);
   });
 
   socket.on("disconnect", () => {
-    console.log('disconnected: ', socket.id, curRoom);
+    console.log("disconnected: ", socket.id, curRoom);
     const roomInfo = rooms.get(curRoom);
     if (roomInfo) {
       console.log("user disconnected", socket.id);

--- a/server/socketio-server.js
+++ b/server/socketio-server.js
@@ -1,7 +1,16 @@
-// Load required modules
-const http = require("http"); // http server core module
-const path = require("path");
-const express = require("express"); // web framework external module
+const express = require("express");
+const path = require("node:path");
+const http = require("node:http");
+// To generate a certificate for local development with https, you can use
+// npx webpack serve --server-type https
+// and stop it with ctrl+c, it will generate the file node_modules/.cache/webpack-dev-server/server.pem
+// Then to enable https on the node server, uncomment the next lines
+// and the webServer line down below.
+// const https = require("node:https");
+// const fs = require("node:fs");
+// const privateKey = fs.readFileSync("node_modules/.cache/webpack-dev-server/server.pem", "utf8");
+// const certificate = fs.readFileSync("node_modules/.cache/webpack-dev-server/server.pem", "utf8");
+// const credentials = { key: privateKey, cert: certificate };
 
 // Set process name
 process.title = "networked-aframe-server";
@@ -33,6 +42,8 @@ app.use(express.static(path.resolve(__dirname, "..", "examples")));
 
 // Start Express http server
 const webServer = http.createServer(app);
+// To enable https on the node server, comment the line above and uncomment the line below
+// const webServer = https.createServer(credentials, app);
 const io = require("socket.io")(webServer);
 
 const rooms = new Map();

--- a/server/socketio-server.js
+++ b/server/socketio-server.js
@@ -114,7 +114,7 @@ io.on("connection", (socket) => {
   });
 
   socket.on("broadcast", (data) => {
-    socket.to(curRoom).broadcast.emit("broadcast", data);
+    socket.to(curRoom).emit("broadcast", data);
   });
 
   socket.on("disconnect", () => {
@@ -126,7 +126,7 @@ io.on("connection", (socket) => {
       delete roomInfo.occupants[socket.id];
       roomInfo.occupantsCount--;
       const occupants = roomInfo.occupants;
-      socket.to(curRoom).broadcast.emit("occupantsChanged", { occupants });
+      socket.to(curRoom).emit("occupantsChanged", { occupants });
 
       if (roomInfo.occupantsCount === 0) {
         console.log("everybody left room");


### PR DESCRIPTION
If you want to test, change in `package.json`
```
"socket.io": "^4.8.1"
```
and run
```
npm install
```

in `examples/basic.html`:
```diff
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.5.0/socket.io.slim.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script> -->
+    <script src="/socket.io/socket.io.js"></script>

     <a-scene
       networked-scene="
       room: basic;
-      debug: true;
-      adapter: wseasyrtc;
+      debug: false;
+      adapter: socketio;
     "
```

To run with node:
```
node server/socketio-server.js
```

To run with deno:
```
cp server/socketio-server.js server/socketio-server.cjs
deno -A server/socketio-server.cjs
```

To run with bun
```
bun server/socketio-server.js
```

deno is good alternative for performance it seems
https://x.com/vincentfretin/status/1863545608100847969