### PR TITLE
Add uws adapter and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ List of the supported adapters:
 | socketio | SocketIO implementation without external library (server supports [room instancing](https://github.com/networked-aframe/networked-aframe/pull/458)) | No | WebSockets | `npm run dev-socketio` |
 | webrtc | Native WebRTC implementation without external library (work in progress, currently no maintainer) | Audio | WebRTC | `npm run dev-socketio` |
 | Firebase | [Firebase](https://firebase.google.com/) for WebRTC signalling (currently no maintainer) | No | WebRTC | See [naf-firebase-adapter](https://github.com/networked-aframe/naf-firebase-adapter) |
-| uWS | Implementation of [uWebSockets](https://github.com/uNetworking/uWebSockets) (currently no maintainer) | No | WebSockets | See [naf-uws-adapter](https://github.com/networked-aframe/naf-uws-adapter) |
+| uws | Uses the highly performant [uWebSockets](https://github.com/uNetworking/uWebSockets) | No | WebSockets | See comments in [server/uws-server.cjs](./server/uws-server.cjs) |
 
 WebRTC in the table means that component updates is using WebRTC Datachannels
 (UDP) instead of the WebSocket (TCP). You still have a WebSocket for the signaling

--- a/server/uws-server.cjs
+++ b/server/uws-server.cjs
@@ -1,0 +1,239 @@
+// Verify the latest version of uWebSockets.js at https://github.com/uNetworking/uWebSockets.js
+// Run:
+//   npm install uNetworking/uWebSockets.js#v20.51.0
+// and start the server:
+//   node server/uws-server.cjs
+// To use the uws adapter, specify it in your index.html networked-scene:
+//   adapter: uws;
+// You can also remove any socket.io and easyrtc script tags from your index.html
+// as they are not needed with uws.
+const uWS = require("uWebSockets.js");
+const path = require("path");
+const fs = require("fs");
+
+// Set process name
+process.title = "networked-aframe-server";
+
+// If you use nginx in front, comment uWS.SSLApp and use uWS.App
+// and in your index.html networked-scene:
+//   adapter: uws;
+//   serverURL: /uws;
+// and in your nginx.conf:
+//   location /uws {
+//     proxy_pass http://127.0.0.1:8080;
+//     proxy_http_version 1.1;
+//     proxy_set_header Upgrade $http_upgrade;
+//     proxy_set_header Connection 'upgrade';
+//     proxy_set_header Host $host;
+//     proxy_cache_bypass $http_upgrade;
+//   }
+// But you would have better performance with uWS.SSLApp and using a dedicated port for uws
+// serverURL: wss://example.com:8080/;
+
+// To generate a self-signed certificate for local development, you can use
+// npx webpack serve --server-type https
+// and stop it with ctrl+c, it will generate the file node_modules/.cache/webpack-dev-server/server.pem
+// Replace the self-signed certificate with a letsencrypt one in production.
+const app = uWS.SSLApp({
+  key_file_name: "node_modules/.cache/webpack-dev-server/server.pem",
+  cert_file_name: "node_modules/.cache/webpack-dev-server/server.pem"
+});
+// const app = uWS.App();
+
+// Get port or default to 8080
+const port = process.env.PORT || 8080;
+
+// Threshold for instancing a room
+const maxOccupantsInRoom = 100;
+
+// Store for rooms and connections
+const rooms = new Map();
+const sockets = new Map();
+
+const encode = (event, data) => JSON.stringify({ event, data });
+
+// MIME types for static file serving
+const MIME_TYPES = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".wav": "audio/wav",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".woff": "application/font-woff",
+  ".ttf": "application/font-ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".otf": "application/font-otf",
+  ".wasm": "application/wasm",
+  ".glb": "model/gltf-binary"
+};
+
+const tmpArray = new Uint32Array(1);
+function generateUniqueId() {
+  return String(crypto.getRandomValues(tmpArray)[0]);
+}
+
+// Static file handler
+function serveStatic(res, reqPath) {
+  let filepath = path.join(__dirname, "..", "examples", reqPath);
+
+  // Serve index.html for directory requests
+  if (!path.extname(filepath)) {
+    filepath = path.join(filepath, "index.html");
+  }
+
+  try {
+    const stat = fs.statSync(filepath);
+    if (!stat.isFile()) {
+      res.writeStatus("404 Not Found").end();
+      return;
+    }
+
+    const ext = path.extname(filepath);
+    const contentType = MIME_TYPES[ext] || "application/octet-stream";
+    const content = fs.readFileSync(filepath);
+
+    res.writeHeader("Content-Type", contentType);
+    res.end(content);
+  } catch (e) {
+    res.writeStatus("404 Not Found").end();
+  }
+}
+
+// Handle HTTP requests
+app.any("/*", (res, req) => {
+  const url = req.getUrl();
+  serveStatic(res, url);
+});
+
+// WebSocket handling
+app.ws("/*", {
+  idleTimeout: 60,
+  maxPayloadLength: 16 * 1024 * 1024,
+  compression: uWS.SHARED_COMPRESSOR,
+  sendPingsAutomatically: true, // that's the default
+
+  open(ws) {
+    const socketId = generateUniqueId();
+    sockets.set(socketId, ws);
+    ws.socketId = socketId;
+    ws.subscribe(socketId);
+    console.log("user connected", socketId);
+  },
+
+  message(ws, message) {
+    const msg = JSON.parse(Buffer.from(message).toString());
+
+    switch (msg.event) {
+      case "joinRoom": {
+        const { room } = msg.data;
+        let curRoom = room;
+        let roomInfo = rooms.get(room);
+
+        if (!roomInfo) {
+          roomInfo = {
+            name: room,
+            occupants: {},
+            occupantsCount: 0
+          };
+          rooms.set(room, roomInfo);
+        }
+
+        if (roomInfo.occupantsCount >= maxOccupantsInRoom) {
+          const roomPrefix = `${room}--`;
+          let availableRoomFound = false;
+          let numberOfInstances = 1;
+
+          for (const [roomName, roomData] of rooms.entries()) {
+            if (roomName.startsWith(roomPrefix)) {
+              numberOfInstances++;
+              if (roomData.occupantsCount < maxOccupantsInRoom) {
+                availableRoomFound = true;
+                curRoom = roomName;
+                roomInfo = roomData;
+                break;
+              }
+            }
+          }
+
+          if (!availableRoomFound) {
+            const newRoomNumber = numberOfInstances + 1;
+            curRoom = `${roomPrefix}${newRoomNumber}`;
+            roomInfo = {
+              name: curRoom,
+              occupants: {},
+              occupantsCount: 0
+            };
+            rooms.set(curRoom, roomInfo);
+          }
+        }
+
+        const joinedTime = Date.now();
+        roomInfo.occupants[ws.socketId] = joinedTime;
+        roomInfo.occupantsCount++;
+        ws.curRoom = curRoom;
+        ws.subscribe(curRoom);
+
+        ws.send(encode("connectSuccess", { joinedTime, socketId: ws.socketId }));
+
+        app.publish(
+          curRoom,
+          encode("occupantsChanged", {
+            occupants: roomInfo.occupants
+          })
+        );
+        break;
+      }
+
+      case "send": {
+        const { to, ...data } = msg.data;
+        app.publish(to, encode("send", data));
+        break;
+      }
+
+      case "broadcast": {
+        if (ws.curRoom) {
+          app.publish(ws.curRoom, encode("broadcast", msg.data));
+        }
+        break;
+      }
+    }
+  },
+
+  close(ws) {
+    const roomInfo = rooms.get(ws.curRoom);
+    if (roomInfo) {
+      console.log("user disconnected", ws.socketId);
+
+      delete roomInfo.occupants[ws.socketId];
+      roomInfo.occupantsCount--;
+
+      app.publish(
+        ws.curRoom,
+        encode("occupantsChanged", {
+          occupants: roomInfo.occupants
+        })
+      );
+
+      if (roomInfo.occupantsCount === 0) {
+        console.log("everybody left room");
+        rooms.delete(ws.curRoom);
+      }
+    }
+
+    sockets.delete(ws.socketId);
+  }
+});
+
+app.listen(port, (token) => {
+  if (token) {
+    console.log(`Listening on https://localhost:${port}`);
+  } else {
+    console.log(`Failed to listen on port ${port}`);
+  }
+});

--- a/src/adapters/AdapterFactory.js
+++ b/src/adapters/AdapterFactory.js
@@ -2,6 +2,7 @@ const WsEasyRtcAdapter = require("./WsEasyRtcAdapter");
 const EasyRtcAdapter = require("./EasyRtcAdapter");
 const WebrtcAdapter = require("./naf-webrtc-adapter");
 const SocketioAdapter = require('./naf-socketio-adapter');
+const UWSAdapter = require('./naf-uws-adapter');
 
 class AdapterFactory {
   constructor() {
@@ -10,6 +11,7 @@ class AdapterFactory {
       "easyrtc": EasyRtcAdapter,
       "socketio": SocketioAdapter,
       "webrtc": WebrtcAdapter,
+      "uws": UWSAdapter,
     };
 
     this.IS_CONNECTED = AdapterFactory.IS_CONNECTED;

--- a/src/adapters/naf-uws-adapter.js
+++ b/src/adapters/naf-uws-adapter.js
@@ -1,0 +1,337 @@
+/* global NAF */
+
+class UWSAdapter {
+  constructor() {
+    this.app = 'default';
+    this.room = 'default';
+    this.occupantListener = null;
+    this.myRoomJoinTime = null;
+    this.myId = null;
+    this.packet = {
+      from: undefined,
+      to: undefined,
+      type: undefined,
+      data: undefined
+    };
+
+    this.occupants = {}; // id -> joinTimestamp
+    this.connectedClients = [];
+
+    this.serverTimeRequests = 0;
+    this.timeOffsets = [];
+    this.avgTimeOffset = 0;
+
+    this.ws = null;
+    this.onWebsocketOpen = this.onWebsocketOpen.bind(this);
+    this.onWebsocketClose = this.onWebsocketClose.bind(this);
+    this.onWebsocketMessage = this.onWebsocketMessage.bind(this);
+
+    // In the event the server restarts and all clients lose connection, reconnect with
+    // some random jitter added to prevent simultaneous reconnection requests.
+    this.initialReconnectionDelay = 1000 * Math.random();
+    this.reconnectionDelay = this.initialReconnectionDelay;
+    this.reconnectionTimeout = null;
+    this.maxReconnectionAttempts = 10;
+    this.reconnectionAttempts = 0;
+    this.isReconnecting = false;
+    this.reconnectionTimeout = null;
+
+    window.addEventListener('offline', () => {
+      console.log('Browser went offline - closing WebSocket');
+      this.reconnect();
+    });
+  }
+
+  setServerUrl(wsUrl) {
+    this.wsUrl = wsUrl;
+  }
+
+  setApp(appName) {
+    this.app = appName;
+  }
+
+  setRoom(roomName) {
+    this.room = roomName;
+  }
+
+  setWebRtcOptions(options) {
+    // No WebRTC support
+  }
+
+  setServerConnectListeners(successListener, failureListener) {
+    this.connectSuccess = successListener;
+    this.connectFailure = failureListener;
+  }
+
+  setRoomOccupantListener(occupantListener) {
+    this.occupantListener = occupantListener;
+  }
+
+  setDataChannelListeners(openListener, closedListener, messageListener) {
+    this.openListener = openListener;
+    this.closedListener = closedListener;
+    this.messageListener = messageListener;
+  }
+
+  connect() {
+    return Promise.all([this.connectToServer(), this.updateTimeOffset()]);
+  }
+
+  connectToServer() {
+    if (!this.wsUrl || this.wsUrl === '/') {
+      if (location.protocol === 'https:') {
+        this.wsUrl = 'wss://' + location.host;
+      } else {
+        this.wsUrl = 'ws://' + location.host;
+      }
+    }
+
+    NAF.log.write('Connecting to WebSocket', this.wsUrl);
+
+    const websocketConnection = new Promise((resolve, reject) => {
+      this.ws = new WebSocket(this.wsUrl);
+
+      this.websocketConnectionPromise = {};
+      this.websocketConnectionPromise.resolve = resolve;
+      this.websocketConnectionPromise.reject = reject;
+
+      this.ws.addEventListener('open', this.onWebsocketOpen);
+      this.ws.addEventListener('close', this.onWebsocketClose);
+      this.ws.addEventListener('message', this.onWebsocketMessage);
+    });
+    return websocketConnection;
+  }
+
+  onWebsocketOpen() {
+    console.log('WebSocket connected');
+    this.reconnectionDelay = this.initialReconnectionDelay;
+    this.reconnectAttempts = 0;
+    if (this.isReconnecting && this.onReconnected) {
+      this.onReconnected();
+    }
+    this.isReconnecting = false;
+    this.joinRoom();
+  }
+
+  onWebsocketClose(event) {
+    // The connection was closed successfully. Don't try to reconnect.
+    if (event.code === 1000 || event.code === 1005) {
+      return;
+    }
+
+    this.websocketConnectionPromise.reject(event);
+
+    if (!this.isReconnecting) {
+      this.isReconnecting = true;
+      console.warn('WebSocket closed unexpectedly.');
+      if (this.onReconnecting) {
+        this.onReconnecting(this.reconnectionDelay);
+      }
+
+      this.reconnectionTimeout = setTimeout(() => this.reconnect(), this.reconnectionDelay);
+    }
+  }
+
+  reconnect() {
+    // Dispose of all networked entities and other resources tied to the session.
+    this.disconnect();
+
+    this.connectToServer()
+      .then(() => {
+        this.reconnectionDelay = this.initialReconnectionDelay;
+        this.reconnectionAttempts = 0;
+
+        if (this.onReconnected) {
+          this.onReconnected();
+        }
+      })
+      .catch((error) => {
+        this.reconnectionDelay += 1000;
+        this.reconnectionAttempts++;
+
+        if (this.reconnectionAttempts > this.maxReconnectionAttempts) {
+          const error = new Error(
+            'Connection could not be reestablished, exceeded maximum number of reconnection attempts.'
+          );
+          if (this.onReconnectionError) {
+            return this.onReconnectionError(error);
+          } else {
+            console.error(error);
+            return;
+          }
+        }
+
+        console.warn('Error during reconnect, retrying.');
+        console.warn(error);
+
+        if (this.onReconnecting) {
+          this.onReconnecting(this.reconnectionDelay);
+        }
+
+        this.reconnectionTimeout = setTimeout(() => this.reconnect(), this.reconnectionDelay);
+      });
+  }
+
+  onWebsocketMessage(event) {
+    const message = JSON.parse(event.data);
+    const { event: eventName, data } = message;
+
+    switch (eventName) {
+      case 'connectSuccess': {
+        const { joinedTime, socketId } = data;
+        this.myRoomJoinTime = joinedTime;
+        this.myId = socketId;
+        this.websocketConnectionPromise.resolve();
+        this.connectSuccess(this.myId);
+        break;
+      }
+
+      case 'occupantsChanged': {
+        const { occupants } = data;
+        this.receivedOccupants(occupants);
+        break;
+      }
+
+      case 'send':
+      case 'broadcast': {
+        const { from, type, data: messageData } = data;
+        this.messageListener(from, type, messageData);
+        break;
+      }
+    }
+  }
+
+  joinRoom() {
+    NAF.log.write('Joining room', this.room);
+    this.send('joinRoom', { room: this.room });
+  }
+
+  receivedOccupants(occupants) {
+    delete occupants[this.myId];
+    this.occupants = occupants;
+    this.occupantListener(occupants);
+  }
+
+  shouldStartConnectionTo(client) {
+    return true;
+  }
+
+  startStreamConnection(remoteId) {
+    this.connectedClients.push(remoteId);
+    this.openListener(remoteId);
+  }
+
+  closeStreamConnection(clientId) {
+    this.connectedClients = this.connectedClients.filter((c) => c !== clientId);
+    this.closedListener(clientId);
+  }
+
+  getConnectStatus(clientId) {
+    const connected = this.connectedClients.indexOf(clientId) !== -1;
+
+    if (connected) {
+      return NAF.adapters.IS_CONNECTED;
+    } else {
+      return NAF.adapters.NOT_CONNECTED;
+    }
+  }
+
+  send(event, data) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ event, data }));
+    }
+  }
+
+  sendData(to, type, data) {
+    this.sendDataGuaranteed(to, type, data);
+  }
+
+  sendDataGuaranteed(to, type, data) {
+    this.packet.from = this.myId;
+    this.packet.to = to;
+    this.packet.type = type;
+    this.packet.data = data;
+    this.send('send', this.packet);
+  }
+
+  broadcastData(type, data) {
+    this.broadcastDataGuaranteed(type, data);
+  }
+
+  broadcastDataGuaranteed(type, data) {
+    this.packet.from = this.myId;
+    this.packet.to = undefined;
+    this.packet.type = type;
+    this.packet.data = data;
+    this.send('broadcast', this.packet);
+  }
+
+  getMediaStream(clientId) {
+    return Promise.reject('Interface method not implemented: getMediaStream');
+  }
+
+  updateTimeOffset() {
+    const clientSentTime = Date.now() + this.avgTimeOffset;
+
+    return fetch(document.location.href, { method: 'HEAD', cache: 'no-cache' }).then((res) => {
+      const precision = 1000;
+      const serverReceivedTime = new Date(res.headers.get('Date')).getTime() + precision / 2;
+      const clientReceivedTime = Date.now();
+      const serverTime = serverReceivedTime + (clientReceivedTime - clientSentTime) / 2;
+      const timeOffset = serverTime - clientReceivedTime;
+
+      this.serverTimeRequests++;
+
+      if (this.serverTimeRequests <= 10) {
+        this.timeOffsets.push(timeOffset);
+      } else {
+        this.timeOffsets[this.serverTimeRequests % 10] = timeOffset;
+      }
+
+      this.avgTimeOffset = this.timeOffsets.reduce((acc, offset) => (acc += offset), 0) / this.timeOffsets.length;
+
+      if (this.serverTimeRequests > 10) {
+        setTimeout(() => this.updateTimeOffset(), 5 * 60 * 1000); // Sync clock every 5 minutes.
+      } else {
+        this.updateTimeOffset();
+      }
+    });
+  }
+
+  getServerTime() {
+    return Date.now() + this.avgTimeOffset;
+  }
+
+  onDisconnect() {
+    if (NAF.clientId === '') return;
+    // Properly remove connected clients and remote entities
+    this.receivedOccupants({});
+    // For entities I'm the creator, reset to empty owner and register
+    // again the onConnected callback to send my entities to all
+    // the participants upon reconnect.
+    for (const entity of Object.values(NAF.entities.entities)) {
+      if (entity.components.networked.data.creator === NAF.clientId) {
+        // The creator and owner will be set to the new NAF.clientId upon reconnect
+        entity.setAttribute('networked', { owner: '', creator: '' });
+        document.body.addEventListener('connected', entity.components.networked.onConnected, false);
+      }
+    }
+    NAF.clientId = '';
+  }
+
+  disconnect() {
+    clearTimeout(this.reconnectionTimeout);
+
+    this.onDisconnect();
+
+    if (this.ws) {
+      this.ws.removeEventListener('open', this.onWebsocketOpen);
+      this.ws.removeEventListener('close', this.onWebsocketClose);
+      this.ws.removeEventListener('message', this.onWebsocketMessage);
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+}
+
+module.exports = UWSAdapter;


### PR DESCRIPTION
Add uws adapter, equivalent of the socketio adapter but using WebSocket directly and with the reconnection logic from the janus adapter.
You can easily compare `src/adapters/naf-socketio-adapter.js` and `src/adapters/naf-uws-adapter.js` if you're interested in the implementation.

Add the uws server based on https://github.com/uNetworking/uWebSockets.js
see comments in the `server/uws-server.cjs` if you're interested in running it. This is the exact equivalent of `server/socketio-server.cjs` that includes room instancing.

On Raspberry Pi 400, 70 moving users with socketio were taking 100% of cpu, with uws server only 30%.
https://x.com/vincentfretin/status/1866053292972822729