### PR TITLE
Update examples to aframe 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Basic Example
 <html>
   <head>
     <title>My Networked-Aframe Scene</title>
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="https://unpkg.com/networked-aframe@^0.14.0/dist/networked-aframe.min.js"></script>

--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -110,7 +110,7 @@ Here's the template we'll start with:
 ```html
 <html>
   <head>
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="https://unpkg.com/networked-aframe@^0.14.0/dist/networked-aframe.min.js"></script>

--- a/examples/360.html
+++ b/examples/360.html
@@ -5,7 +5,7 @@
     <title>360 Image Example — Networked-Aframe</title>
     <meta name="description" content="360 Image Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -47,7 +47,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/adapter-test/adapter-test-receive.html
+++ b/examples/adapter-test/adapter-test-receive.html
@@ -5,7 +5,7 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -70,7 +70,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
     </a-scene>
 

--- a/examples/adapter-test/adapter-test-send.html
+++ b/examples/adapter-test/adapter-test-send.html
@@ -5,7 +5,7 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -49,7 +49,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <!-- <a-scene embedded networked-scene="
       room: dev;

--- a/examples/basic-ar.html
+++ b/examples/basic-ar.html
@@ -5,7 +5,7 @@
     <title>Basic AR Example — Networked-Aframe</title>
     <meta name="description" content="Basic AR Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -61,7 +61,6 @@
       debug: true;
       onConnect: onARConnect;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-audio.html
+++ b/examples/basic-audio.html
@@ -5,7 +5,7 @@
     <title>Positional Audio Example — Networked-Aframe</title>
     <meta name="description" content="Positional Audio Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -50,7 +50,6 @@
       adapter: easyrtc;
       audio: true;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-chat.html
+++ b/examples/basic-chat.html
@@ -5,7 +5,7 @@
     <title>Basic Chat — Networked-Aframe</title>
     <meta name="description" content="Basic Chat — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
     <!--   NAF basic requirements   -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
@@ -192,7 +192,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-events.html
+++ b/examples/basic-events.html
@@ -5,7 +5,7 @@
     <title>Events Example — Networked-Aframe</title>
     <meta name="description" content="Events Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -48,7 +48,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-multi-streams.html
+++ b/examples/basic-multi-streams.html
@@ -5,7 +5,7 @@
     <title>Multi Streams Example — Networked-Aframe</title>
     <meta name="description" content="Multi Streams Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -46,7 +46,6 @@
       audio: false;
       video: true;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-persistent.html
+++ b/examples/basic-persistent.html
@@ -5,7 +5,7 @@
     <title>Persistent Sphere Example — Networked-Aframe</title>
     <meta name="description" content="Persistent Sphere Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -64,7 +64,6 @@
         room: basic-persistent;
         debug: true;
         adapter: wseasyrtc"
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic-video.html
+++ b/examples/basic-video.html
@@ -5,7 +5,7 @@
     <title>Video Streaming Example — Networked-Aframe</title>
     <meta name="description" content="Video Streaming Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -46,7 +46,6 @@
       audio: false;
       video: true;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,7 +5,7 @@
     <title>Basic Example — Networked-Aframe</title>
     <meta name="description" content="Basic Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
     <!--   NAF basic requirements   -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
@@ -93,7 +93,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/child-entities.html
+++ b/examples/child-entities.html
@@ -5,7 +5,7 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -57,7 +57,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/disconnect.html
+++ b/examples/disconnect.html
@@ -5,7 +5,7 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -42,7 +42,7 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <a-scene renderer="physicallyCorrectLights: true;">
+    <a-scene>
       <a-assets>
         <!-- Templates -->
 

--- a/examples/dynamic-room.html
+++ b/examples/dynamic-room.html
@@ -5,7 +5,7 @@
     <title>Positional Audio Example — Networked-Aframe</title>
     <meta name="description" content="Positional Audio Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -44,7 +44,7 @@
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
   </head>
   <body>
-    <a-scene dynamic-room renderer="physicallyCorrectLights: true;">
+    <a-scene dynamic-room>
       <a-assets>
         <!-- Templates -->
 

--- a/examples/google-blocks.html
+++ b/examples/google-blocks.html
@@ -5,7 +5,7 @@
     <title>Basic Example — Networked-Aframe</title>
     <meta name="description" content="Basic Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -42,7 +42,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <a-asset-item id="raccoon-obj" src="./assets/Raccoon_Blocks/model.obj"></a-asset-item>

--- a/examples/nametag.html
+++ b/examples/nametag.html
@@ -5,7 +5,7 @@
     <title>Nametag Example — Networked-Aframe</title>
     <meta name="description" content="Nametag — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
@@ -144,7 +144,6 @@
         debug: true;
         adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <template id="rig-template">

--- a/examples/ownership-transfer.html
+++ b/examples/ownership-transfer.html
@@ -5,7 +5,7 @@
     <title>Ownership Transfer Example — Networked-Aframe</title>
     <meta name="description" content="Ownership Transfer Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -74,7 +74,6 @@
         debug: true;
         adapter: wseasyrtc;
       "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/persistent-peer-to-peer.html
+++ b/examples/persistent-peer-to-peer.html
@@ -5,7 +5,7 @@
     <title>Spawned Persistent Spheres Example — Networked-Aframe</title>
     <meta name="description" content="Spawned Persistent Spheres Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -74,7 +74,6 @@
         room: persistent-peer-to-peer;
         debug: true;
         adapter: wseasyrtc"
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/shooter-ar.html
+++ b/examples/shooter-ar.html
@@ -5,7 +5,7 @@
     <title>Shooter AR Example — Networked-Aframe</title>
     <meta name="description" content="Shooter AR Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -35,7 +35,6 @@
       adapter: wseasyrtc;
       onConnect: onARConnect;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/shooter.html
+++ b/examples/shooter.html
@@ -5,7 +5,7 @@
     <title>Shooter Example — Networked-Aframe</title>
     <meta name="description" content="Shooter Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -51,7 +51,6 @@
       debug: true;
       adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -5,7 +5,7 @@
     <title>Tracked Controllers Example — Networked-Aframe</title>
     <meta name="description" content="Tracked Controllers — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
@@ -70,7 +70,6 @@
         debug: true;
         adapter: wseasyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <template id="rig-template">

--- a/examples/webrtc.html
+++ b/examples/webrtc.html
@@ -5,7 +5,7 @@
     <title>Basic Example — Networked-Aframe</title>
     <meta name="description" content="Basic Example — Networked-Aframe" />
 
-    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/dist/networked-aframe.js"></script>
@@ -48,7 +48,6 @@
       debug: true;
       adapter: easyrtc;
     "
-      renderer="physicallyCorrectLights: true;"
     >
       <a-assets>
         <!-- Templates -->


### PR DESCRIPTION
Update examples to aframe 1.7.0
and remove `renderer="physicallyCorrectLights: true;"` that is now the default.