### PR TITLE
Remove ambient light everywhere

### DIFF
--- a/examples/basic-audio.html
+++ b/examples/basic-audio.html
@@ -87,7 +87,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="actions">

--- a/examples/basic-chat.html
+++ b/examples/basic-chat.html
@@ -220,7 +220,6 @@
       </a-assets>
 
       <a-entity environment="preset:starry;groundColor:#000000;"></a-entity>
-      <a-entity light="type:ambient;intensity:0.5"></a-entity>
 
       <!--   Here we declare only the local user's avatar, which we then broadcast to other users     -->
       <!--   The 'spawn-in-circle' component will set the position and rotation of #rig;

--- a/examples/basic-events.html
+++ b/examples/basic-events.html
@@ -85,7 +85,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <script>

--- a/examples/basic-multi-streams.html
+++ b/examples/basic-multi-streams.html
@@ -91,7 +91,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="actions">

--- a/examples/basic-persistent.html
+++ b/examples/basic-persistent.html
@@ -116,7 +116,6 @@
       -->
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="controls">

--- a/examples/basic-video.html
+++ b/examples/basic-video.html
@@ -90,7 +90,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="actions">

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -121,7 +121,6 @@
       </a-assets>
 
       <a-entity environment="preset:starry;groundColor:#000000;"></a-entity>
-      <a-entity light="type:ambient;intensity:0.5"></a-entity>
 
       <!--   Here we declare only the local user's avatar, which we then broadcast to other users     -->
       <!--   The 'spawn-in-circle' component will set the position and rotation of #rig;

--- a/examples/child-entities.html
+++ b/examples/child-entities.html
@@ -98,7 +98,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <script>

--- a/examples/disconnect.html
+++ b/examples/disconnect.html
@@ -79,7 +79,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <script>

--- a/examples/dynamic-room.html
+++ b/examples/dynamic-room.html
@@ -81,7 +81,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="actions">

--- a/examples/nametag.html
+++ b/examples/nametag.html
@@ -176,7 +176,6 @@
       </a-assets>
 
       <a-entity environment="preset:starry;groundColor:#000000;"></a-entity>
-      <a-entity light="type:ambient;intensity:0.5"></a-entity>
 
       <a-entity id="rig" movement-controls="fly:true;" spawn-in-circle="radius:3" networked="template:#rig-template;">
         <a-entity

--- a/examples/ownership-transfer.html
+++ b/examples/ownership-transfer.html
@@ -119,7 +119,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="controls">

--- a/examples/persistent-peer-to-peer.html
+++ b/examples/persistent-peer-to-peer.html
@@ -115,7 +115,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <div class="controls">

--- a/examples/shooter.html
+++ b/examples/shooter.html
@@ -100,7 +100,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <script>

--- a/examples/tracked-controllers.html
+++ b/examples/tracked-controllers.html
@@ -92,7 +92,6 @@
       </a-assets>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
 
       <a-entity id="rig" movement-controls="fly:true;" spawn-in-circle="radius:3" networked="template:#rig-template;">
         <a-entity

--- a/examples/webrtc.html
+++ b/examples/webrtc.html
@@ -85,7 +85,6 @@
       </a-entity>
 
       <a-entity environment="preset:arches"></a-entity>
-      <a-entity light="type:ambient;intensity:1.0"></a-entity>
     </a-scene>
 
     <script>


### PR DESCRIPTION
Remove ambient light everywhere that was used to compensate a bug in A-Frame 1.6.0 environment 1.3.7 with physicallyCorrectLights: true, scene looks better without that extra light in A-Frame 1.7.0 environment 1.5.0.