### PR TITLE
Fix easyrtc and wseasyrtc adapters to work with open-easyrtc >= 2.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "buffered-interpolation": "Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b",
         "express": "^4.17.3",
-        "open-easyrtc": "^2.1.0",
+        "open-easyrtc": "^2.1.7",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -7500,9 +7500,9 @@
       }
     },
     "node_modules/open-easyrtc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/open-easyrtc/-/open-easyrtc-2.1.4.tgz",
-      "integrity": "sha512-CEmT/QEYN30iT8rZ97Jvawg8GuGRNZNoa9xHIxP/0R9WpOtdq1TQu3cb8WUwHE53E628vgYiTA80T8oA62nLzQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/open-easyrtc/-/open-easyrtc-2.1.7.tgz",
+      "integrity": "sha512-TXOsElN2OMw0KldGmUE0/wssYcrK0R+jGo7PdgfgCQNBzbIubXjIyShVvhZaYSv+uHtK2sG/WzR01Ch2lnigtg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "buffered-interpolation": "Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b",
     "express": "^4.17.3",
-    "open-easyrtc": "^2.1.0",
+    "open-easyrtc": "^2.1.7",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/src/adapters/EasyRtcAdapter.js
+++ b/src/adapters/EasyRtcAdapter.js
@@ -48,7 +48,6 @@ class EasyRtcAdapter extends NoOpAdapter {
   setRoom(roomName) {
     this.room = roomName;
     this.destination.targetRoom = this.room;
-    this.easyrtc.joinRoom(roomName, null);
   }
 
   // options: { datachannel: bool, audio: bool, video: bool }
@@ -121,8 +120,13 @@ class EasyRtcAdapter extends NoOpAdapter {
         this._connect(resolve, reject);
       })
     ]).then(([_, clientId]) => {
-      this._myRoomJoinTime = this._getRoomJoinTime(clientId);
-      this.connectSuccess(clientId);
+      this.easyrtc.joinRoom(this.room, null,
+        () => {
+          this._myRoomJoinTime = this._getRoomJoinTime(clientId);
+          this.connectSuccess(clientId);
+        },
+        (errorCode, errorText) => { this.connectFailure(errorCode, errorText); }
+      );
     }).catch(this.connectFailure);
   }
 

--- a/src/adapters/WsEasyRtcAdapter.js
+++ b/src/adapters/WsEasyRtcAdapter.js
@@ -30,7 +30,6 @@ class WsEasyRtcInterface extends NoOpAdapter {
   setRoom(roomName) {
     this.room = roomName;
     this.destination.targetRoom = this.room;
-    this.easyrtc.joinRoom(roomName, null);
   }
 
   setWebRtcOptions(options) {
@@ -90,7 +89,10 @@ class WsEasyRtcInterface extends NoOpAdapter {
         this.easyrtc.connect(this.app, resolve, reject);
       })
     ]).then(([_, clientId]) => {
-      this.connectSuccess(clientId);
+      this.easyrtc.joinRoom(this.room, null,
+        () => { this.connectSuccess(clientId); },
+        (errorCode, errorText) => { this.connectFailure(errorCode, errorText); }
+      );
     }).catch(this.connectFailure);
   }
 


### PR DESCRIPTION
Update open-easyrtc to 2.1.7, fix easyrtc and wseasyrtc adapters to call `connect` before `joinRoom`, that's required since 2.1.5.

The change of behavior of the `joinRoom` function for a patch version was reported in https://github.com/open-easyrtc/open-easyrtc/issues/142

Claude Code:
Here's a summary of the changes:

Root cause: `setRoom()` was calling `easyrtc.joinRoom()` immediately, but NAF calls `setRoom()` before `connect()` (see NetworkConnection.js:37 vs :57). Since open-easyrtc 2.1.5, `joinRoom()` now throws if `webSocket` isn't set yet.

Fix in both `WsEasyRtcAdapter.js` and `EasyRtcAdapter.js`:

1. `setRoom()` — removed the `easyrtc.joinRoom()` call, now just stores the room name
2. `connect()` — moved `joinRoom()` to after `easyrtc.connect()` succeeds, using its success/failure callbacks to then proceed with `connectSuccess`/`connectFailure`

This matches the pattern used in all open-easyrtc demo examples: set up listeners first, connect, then join rooms only after the websocket is established.

Vincent:
That's what we do already in `naf-socketio-adapter.js` and `naf-uws-adapter.js` so the changes are coherent with all adapters now.